### PR TITLE
feat: add onFailure callback as counterpart to onSuccess

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,6 +1026,7 @@ You can use the following callbacks to log retry attempts and errors:
 - `onError` is invoked if an error occurs.
 - `onRetry` is invoked before attempting a retry.
 - `onSuccess` is invoked after a successful request with the model that handled it.
+- `onFailure` is invoked when the request ultimately fails and no retry could recover it.
 
 ```typescript
 const retryableModel = createRetryable({
@@ -1049,8 +1050,16 @@ const retryableModel = createRetryable({
       `Request handled by ${context.current.model.provider}/${context.current.model.modelId}`,
     );
   },
+  onFailure: (context) => {
+    console.error(
+      `Request failed after ${context.attempts.length} attempts:`,
+      context.error,
+    );
+  },
 });
 ```
+
+`onSuccess` and `onFailure` are counterparts: exactly one of them is invoked per request once its final outcome is known. `onFailure` fires when the error could not be recovered by a retry, whether because no retryable matched, all retries were exhausted, or the retry itself failed. `context.error` is the error surfaced to the caller (a [`RetryError`](#all-retries-failed) wrapping every attempt error when more than one attempt was made, otherwise the original error), and `context.current` is the final failed attempt. Neither callback fires when retries are disabled.
 
 #### Reset
 
@@ -1210,6 +1219,7 @@ interface RetryableModelOptions<
     context: RetryContext<MODEL>,
   ) => void | OnRetryOverrides<MODEL> | Promise<void | OnRetryOverrides<MODEL>>;
   onSuccess?: (context: SuccessContext<MODEL>) => void;
+  onFailure?: (context: FailureContext<MODEL>) => void;
 }
 ```
 
@@ -1223,6 +1233,7 @@ interface RetryableModelOptions<
 - `onError`: Callback invoked when an error occurs.
 - `onRetry`: Callback invoked before attempting a retry. May optionally return an `OnRetryOverrides` object (or a `Promise` of one) to override `options.*` for the upcoming attempt only. See [Dynamic Call Options via `onRetry`](#dynamic-call-options-via-onretry).
 - `onSuccess`: Callback invoked after a successful request. Receives the model that handled the request and all previous attempts.
+- `onFailure`: Callback invoked when the request ultimately fails and no retry could recover it (no retryable matched, all retries exhausted, or the retry itself failed).
 
 #### `Reset`
 
@@ -1306,6 +1317,18 @@ interface SuccessAttempt {
     | LanguageModelV3CallOptions
     | EmbeddingModelV3CallOptions
     | ImageModelV3CallOptions;
+}
+```
+
+#### `FailureContext`
+
+The `FailureContext` object is passed to the `onFailure` callback when a request ultimately fails. `current` is the final failed attempt (an error attempt, see [`RetryAttempt`](#retryattempt)) and `error` is the error surfaced to the caller, a [`RetryError`](#all-retries-failed) wrapping every attempt error when more than one attempt was made, otherwise the original error.
+
+```typescript
+interface FailureContext {
+  current: RetryErrorAttempt;
+  attempts: Array<RetryAttempt>;
+  error: unknown;
 }
 ```
 

--- a/src/internal/retryable-embedding-model.test.ts
+++ b/src/internal/retryable-embedding-model.test.ts
@@ -18,6 +18,7 @@ import { isErrorAttempt } from './guards.js';
 type OnError = Required<RetryableModelOptions<EmbeddingModel>>['onError'];
 type OnRetry = Required<RetryableModelOptions<EmbeddingModel>>['onRetry'];
 type OnSuccess = Required<RetryableModelOptions<EmbeddingModel>>['onSuccess'];
+type OnFailure = Required<RetryableModelOptions<EmbeddingModel>>['onFailure'];
 
 describe('embed', () => {
   it('should embed successfully when no errors occur', async () => {
@@ -712,6 +713,85 @@ describe('embed', () => {
       await expect(result).rejects.toThrow();
 
       expect(onSuccessSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onFailure', () => {
+    it('should call onFailure with raw error when no retry is available', async () => {
+      // Arrange
+      const baseModel = new MockEmbeddingModel({ doEmbed: nonRetryableError });
+      const onFailureSpy = vi.fn<OnFailure>();
+
+      // Act
+      const result = embed({
+        model: createRetryable({
+          model: baseModel,
+          retries: [],
+          onFailure: onFailureSpy,
+        }),
+        value: 'Hello!',
+      });
+      await expect(result).rejects.toThrow();
+
+      // Assert
+      expect(onFailureSpy).toHaveBeenCalledTimes(1);
+
+      const failureCall = onFailureSpy.mock.calls[0]![0];
+      expect(failureCall.current.type).toBe('error');
+      expect(failureCall.current.model).toBe(baseModel);
+      expect(failureCall.attempts.length).toBe(1);
+      expect(failureCall.error).toBe(nonRetryableError);
+    });
+
+    it('should call onFailure with RetryError when retries are exhausted', async () => {
+      // Arrange
+      const baseModel = new MockEmbeddingModel({ doEmbed: retryableError });
+      const fallbackModel = new MockEmbeddingModel({
+        doEmbed: nonRetryableError,
+      });
+      const onFailureSpy = vi.fn<OnFailure>();
+
+      // Act
+      const result = embed({
+        model: createRetryable({
+          model: baseModel,
+          retries: [fallbackModel],
+          onFailure: onFailureSpy,
+        }),
+        value: 'Hello!',
+      });
+      await expect(result).rejects.toThrow();
+
+      // Assert
+      expect(onFailureSpy).toHaveBeenCalledTimes(1);
+
+      const failureCall = onFailureSpy.mock.calls[0]![0];
+      expect(failureCall.current.type).toBe('error');
+      expect(failureCall.current.model).toBe(fallbackModel);
+      expect(failureCall.attempts.length).toBe(2);
+      expect(failureCall.error).toBeInstanceOf(RetryError);
+    });
+
+    it('should NOT call onFailure on success', async () => {
+      // Arrange
+      const baseModel = new MockEmbeddingModel({ doEmbed: mockEmbeddings });
+      const onFailureSpy = vi.fn<OnFailure>();
+      const onSuccessSpy = vi.fn<OnSuccess>();
+
+      // Act
+      await embed({
+        model: createRetryable({
+          model: baseModel,
+          retries: [],
+          onFailure: onFailureSpy,
+          onSuccess: onSuccessSpy,
+        }),
+        value: 'Hello!',
+      });
+
+      // Assert
+      expect(onSuccessSpy).toHaveBeenCalledTimes(1);
+      expect(onFailureSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/internal/retryable-embedding-model.ts
+++ b/src/internal/retryable-embedding-model.ts
@@ -127,14 +127,19 @@ export class RetryableEmbeddingModel
         });
         return { result, attempts, callOptions: retryCallOptions };
       } catch (error) {
+        const { retryModel, attempt, finalError } = await this.handleError(
+          error,
+          attempts,
+          retryCallOptions,
+        );
+
+        attempts.push(attempt);
+
         /**
-         * `handleError` throws when no retry matched. Record the attempt as
-         * failed before that error propagates.
+         * No retry matched. Record the attempt as failed and throw the
+         * surfaced error.
          */
-        let decision: Awaited<ReturnType<typeof this.handleError>>;
-        try {
-          decision = await this.handleError(error, attempts, retryCallOptions);
-        } catch (finalError) {
+        if (!retryModel) {
           input.recorder?.endAttempt({
             attempt: attemptNumber,
             outcome: 'failure',
@@ -142,10 +147,6 @@ export class RetryableEmbeddingModel
           });
           throw finalError;
         }
-
-        const { retryModel, attempt } = decision;
-
-        attempts.push(attempt);
 
         /**
          * If the inbound abort signal is already aborted and the chosen
@@ -231,18 +232,32 @@ export class RetryableEmbeddingModel
     const retryModel = await findRetryModel(this.options.retries, context);
 
     /**
-     * Handler didn't return any models to try next, rethrow the error.
-     * If we retried the request, wrap the error into a `RetryError` for better visibility.
+     * Handler didn't return any models to try next. Compute the error to
+     * surface: if we retried the request, wrap it into a `RetryError` for
+     * better visibility; otherwise surface the original error. The caller
+     * pushes the attempt and throws `finalError`.
      */
-    if (!retryModel) {
-      if (updatedAttempts.length > 1) {
-        throw prepareRetryError(error, updatedAttempts);
-      }
+    const finalError = retryModel
+      ? undefined
+      : updatedAttempts.length > 1
+        ? prepareRetryError(error, updatedAttempts)
+        : error;
 
-      throw error;
-    }
+    return { retryModel, attempt: errorAttempt, finalError };
+  }
 
-    return { retryModel, attempt: errorAttempt };
+  /**
+   * Fire the `onFailure` callback for a terminally failed operation. The
+   * final attempt (last entry of `attempts`) is surfaced as `current`.
+   */
+  private emitFailure(
+    attempts: Array<RetryErrorAttempt<EmbeddingModel>>,
+    error: unknown,
+  ) {
+    if (!this.options.onFailure) return;
+    const current = attempts.at(-1);
+    if (!current) return;
+    this.options.onFailure({ current, attempts, error });
   }
 
   async doEmbed(
@@ -271,17 +286,19 @@ export class RetryableEmbeddingModel
       },
     );
 
+    /**
+     * Shared attempts array, threaded into `withRetry` so it stays populated
+     * (including the final failed attempt) when the retry loop throws.
+     */
+    const attempts: Array<RetryErrorAttempt<EmbeddingModel>> = [];
     let operationError: unknown;
     try {
-      const {
-        result,
-        attempts,
-        callOptions: finalCallOptions,
-      } = await this.withRetry({
+      const { result, callOptions: finalCallOptions } = await this.withRetry({
         fn: async (retryCallOptions) => {
           return this.currentModel.doEmbed(retryCallOptions);
         },
         callOptions: callOptions,
+        attempts,
         recorder,
       });
 
@@ -300,6 +317,7 @@ export class RetryableEmbeddingModel
       return result;
     } catch (error) {
       operationError = error;
+      this.emitFailure(attempts, error);
       throw error;
     } finally {
       recorder?.endOperation({

--- a/src/internal/retryable-image-model.test.ts
+++ b/src/internal/retryable-image-model.test.ts
@@ -30,6 +30,7 @@ import { isErrorAttempt } from './guards.js';
 type OnError = Required<RetryableModelOptions<ImageModel>>['onError'];
 type OnRetry = Required<RetryableModelOptions<ImageModel>>['onRetry'];
 type OnSuccess = Required<RetryableModelOptions<ImageModel>>['onSuccess'];
+type OnFailure = Required<RetryableModelOptions<ImageModel>>['onFailure'];
 
 const noImageError = new NoImageGeneratedError({
   message: `No image generated`,
@@ -481,6 +482,85 @@ describe('generateImage', () => {
       await expect(result).rejects.toThrow();
 
       expect(onSuccessSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onFailure', () => {
+    it('should call onFailure with raw error when no retry is available', async () => {
+      // Arrange
+      const baseModel = new MockImageModel({ doGenerate: nonRetryableError });
+      const onFailureSpy = vi.fn<OnFailure>();
+
+      // Act
+      const result = generateImage({
+        model: createRetryable({
+          model: baseModel,
+          retries: [],
+          onFailure: onFailureSpy,
+        }),
+        prompt: `A beautiful sunset`,
+      });
+      await expect(result).rejects.toThrow();
+
+      // Assert
+      expect(onFailureSpy).toHaveBeenCalledTimes(1);
+
+      const failureCall = onFailureSpy.mock.calls[0]![0];
+      expect(failureCall.current.type).toBe('error');
+      expect(failureCall.current.model).toBe(baseModel);
+      expect(failureCall.attempts.length).toBe(1);
+      expect(failureCall.error).toBe(nonRetryableError);
+    });
+
+    it('should call onFailure with RetryError when retries are exhausted', async () => {
+      // Arrange
+      const baseModel = new MockImageModel({ doGenerate: retryableError });
+      const fallbackModel = new MockImageModel({
+        doGenerate: nonRetryableError,
+      });
+      const onFailureSpy = vi.fn<OnFailure>();
+
+      // Act
+      const result = generateImage({
+        model: createRetryable({
+          model: baseModel,
+          retries: [fallbackModel],
+          onFailure: onFailureSpy,
+        }),
+        prompt: `A beautiful sunset`,
+      });
+      await expect(result).rejects.toThrow();
+
+      // Assert
+      expect(onFailureSpy).toHaveBeenCalledTimes(1);
+
+      const failureCall = onFailureSpy.mock.calls[0]![0];
+      expect(failureCall.current.type).toBe('error');
+      expect(failureCall.current.model).toBe(fallbackModel);
+      expect(failureCall.attempts.length).toBe(2);
+      expect(failureCall.error).toBeInstanceOf(RetryError);
+    });
+
+    it('should NOT call onFailure on success', async () => {
+      // Arrange
+      const baseModel = new MockImageModel({ doGenerate: mockImageResult });
+      const onFailureSpy = vi.fn<OnFailure>();
+      const onSuccessSpy = vi.fn<OnSuccess>();
+
+      // Act
+      await generateImage({
+        model: createRetryable({
+          model: baseModel,
+          retries: [],
+          onFailure: onFailureSpy,
+          onSuccess: onSuccessSpy,
+        }),
+        prompt: `A beautiful sunset`,
+      });
+
+      // Assert
+      expect(onSuccessSpy).toHaveBeenCalledTimes(1);
+      expect(onFailureSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/internal/retryable-image-model.ts
+++ b/src/internal/retryable-image-model.ts
@@ -122,14 +122,19 @@ export class RetryableImageModel
         });
         return { result, attempts, callOptions: retryCallOptions };
       } catch (error) {
+        const { retryModel, attempt, finalError } = await this.handleError(
+          error,
+          attempts,
+          retryCallOptions,
+        );
+
+        attempts.push(attempt);
+
         /**
-         * `handleError` throws when no retry matched. Record the attempt as
-         * failed before that error propagates.
+         * No retry matched. Record the attempt as failed and throw the
+         * surfaced error.
          */
-        let decision: Awaited<ReturnType<typeof this.handleError>>;
-        try {
-          decision = await this.handleError(error, attempts, retryCallOptions);
-        } catch (finalError) {
+        if (!retryModel) {
           input.recorder?.endAttempt({
             attempt: attemptNumber,
             outcome: 'failure',
@@ -137,10 +142,6 @@ export class RetryableImageModel
           });
           throw finalError;
         }
-
-        const { retryModel, attempt } = decision;
-
-        attempts.push(attempt);
 
         /**
          * If the inbound abort signal is already aborted and the chosen
@@ -226,18 +227,32 @@ export class RetryableImageModel
     const retryModel = await findRetryModel(this.options.retries, context);
 
     /**
-     * Handler didn't return any models to try next, rethrow the error.
-     * If we retried the request, wrap the error into a `RetryError` for better visibility.
+     * Handler didn't return any models to try next. Compute the error to
+     * surface: if we retried the request, wrap it into a `RetryError` for
+     * better visibility; otherwise surface the original error. The caller
+     * pushes the attempt and throws `finalError`.
      */
-    if (!retryModel) {
-      if (updatedAttempts.length > 1) {
-        throw prepareRetryError(error, updatedAttempts);
-      }
+    const finalError = retryModel
+      ? undefined
+      : updatedAttempts.length > 1
+        ? prepareRetryError(error, updatedAttempts)
+        : error;
 
-      throw error;
-    }
+    return { retryModel, attempt: errorAttempt, finalError };
+  }
 
-    return { retryModel, attempt: errorAttempt };
+  /**
+   * Fire the `onFailure` callback for a terminally failed operation. The
+   * final attempt (last entry of `attempts`) is surfaced as `current`.
+   */
+  private emitFailure(
+    attempts: Array<RetryErrorAttempt<ImageModel>>,
+    error: unknown,
+  ) {
+    if (!this.options.onFailure) return;
+    const current = attempts.at(-1);
+    if (!current) return;
+    this.options.onFailure({ current, attempts, error });
   }
 
   async doGenerate(
@@ -266,17 +281,19 @@ export class RetryableImageModel
       },
     );
 
+    /**
+     * Shared attempts array, threaded into `withRetry` so it stays populated
+     * (including the final failed attempt) when the retry loop throws.
+     */
+    const attempts: Array<RetryErrorAttempt<ImageModel>> = [];
     let operationError: unknown;
     try {
-      const {
-        result,
-        attempts,
-        callOptions: finalCallOptions,
-      } = await this.withRetry({
+      const { result, callOptions: finalCallOptions } = await this.withRetry({
         fn: async (retryCallOptions) => {
           return this.currentModel.doGenerate(retryCallOptions);
         },
         callOptions: callOptions,
+        attempts,
         recorder,
       });
 
@@ -295,6 +312,7 @@ export class RetryableImageModel
       return result;
     } catch (error) {
       operationError = error;
+      this.emitFailure(attempts, error);
       throw error;
     } finally {
       recorder?.endOperation({

--- a/src/internal/retryable-language-model.test.ts
+++ b/src/internal/retryable-language-model.test.ts
@@ -10,6 +10,7 @@ import {
   collectParts,
   contentFilterResult,
   errorFromChunks,
+  errorStreamChunks,
   finishReason,
   languageCallOptions,
   MockLanguageModel,
@@ -36,6 +37,7 @@ import { isErrorAttempt, isResultAttempt } from './guards.js';
 type OnError = Required<RetryableModelOptions<LanguageModel>>['onError'];
 type OnRetry = Required<RetryableModelOptions<LanguageModel>>['onRetry'];
 type OnSuccess = Required<RetryableModelOptions<LanguageModel>>['onSuccess'];
+type OnFailure = Required<RetryableModelOptions<LanguageModel>>['onFailure'];
 
 const prompt = 'Hello!';
 
@@ -1011,6 +1013,113 @@ describe('generateText', () => {
       });
       await expect(result).rejects.toThrow();
 
+      expect(onSuccessSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onFailure', () => {
+    it('should call onFailure with raw error when no retry is available', async () => {
+      // Arrange
+      const baseModel = new MockLanguageModel({
+        doGenerate: nonRetryableError,
+      });
+      const onFailureSpy = vi.fn<OnFailure>();
+
+      // Act
+      const result = generateText({
+        model: createRetryable({
+          model: baseModel,
+          retries: [],
+          onFailure: onFailureSpy,
+        }),
+        prompt,
+      });
+      await expect(result).rejects.toThrow();
+
+      // Assert
+      expect(onFailureSpy).toHaveBeenCalledTimes(1);
+
+      const failureCall = onFailureSpy.mock.calls[0]![0];
+      expect(failureCall.current.type).toBe('error');
+      expect(failureCall.current.model).toBe(baseModel);
+      expect(failureCall.attempts.length).toBe(1);
+      expect(failureCall.error).toBe(nonRetryableError);
+    });
+
+    it('should call onFailure with RetryError when retries are exhausted', async () => {
+      // Arrange
+      const baseModel = new MockLanguageModel({ doGenerate: retryableError });
+      const fallbackModel = new MockLanguageModel({
+        doGenerate: nonRetryableError,
+      });
+      const onFailureSpy = vi.fn<OnFailure>();
+
+      // Act
+      const result = generateText({
+        model: createRetryable({
+          model: baseModel,
+          retries: [fallbackModel],
+          onFailure: onFailureSpy,
+        }),
+        prompt,
+      });
+      await expect(result).rejects.toThrow();
+
+      // Assert
+      expect(onFailureSpy).toHaveBeenCalledTimes(1);
+
+      const failureCall = onFailureSpy.mock.calls[0]![0];
+      expect(failureCall.current.type).toBe('error');
+      expect(failureCall.current.model).toBe(fallbackModel);
+      expect(failureCall.attempts.length).toBe(2);
+      expect(failureCall.error).toBeInstanceOf(RetryError);
+    });
+
+    it('should NOT call onFailure on success', async () => {
+      // Arrange
+      const baseModel = new MockLanguageModel({ doGenerate: mockResult });
+      const onFailureSpy = vi.fn<OnFailure>();
+      const onSuccessSpy = vi.fn<OnSuccess>();
+
+      // Act
+      await generateText({
+        model: createRetryable({
+          model: baseModel,
+          retries: [],
+          onFailure: onFailureSpy,
+          onSuccess: onSuccessSpy,
+        }),
+        prompt,
+      });
+
+      // Assert
+      expect(onSuccessSpy).toHaveBeenCalledTimes(1);
+      expect(onFailureSpy).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call onSuccess on failure', async () => {
+      // Arrange
+      const baseModel = new MockLanguageModel({ doGenerate: retryableError });
+      const fallbackModel = new MockLanguageModel({
+        doGenerate: nonRetryableError,
+      });
+      const onFailureSpy = vi.fn<OnFailure>();
+      const onSuccessSpy = vi.fn<OnSuccess>();
+
+      // Act
+      const result = generateText({
+        model: createRetryable({
+          model: baseModel,
+          retries: [fallbackModel],
+          onFailure: onFailureSpy,
+          onSuccess: onSuccessSpy,
+        }),
+        prompt,
+      });
+      await expect(result).rejects.toThrow();
+
+      // Assert
+      expect(onFailureSpy).toHaveBeenCalledTimes(1);
       expect(onSuccessSpy).not.toHaveBeenCalled();
     });
   });
@@ -2505,7 +2614,7 @@ describe('streamText', () => {
             "response": {
               "headers": undefined,
               "id": "aitxt-mock-id",
-              "modelId": "mock-model-140",
+              "modelId": "mock-model-146",
               "timestamp": 1970-01-01T00:00:00.000Z,
             },
             "type": "finish-step",
@@ -2618,7 +2727,7 @@ describe('streamText', () => {
             "response": {
               "headers": undefined,
               "id": "aitxt-mock-id",
-              "modelId": "mock-model-142",
+              "modelId": "mock-model-148",
               "timestamp": 1970-01-01T00:00:00.000Z,
             },
             "type": "finish-step",
@@ -3724,6 +3833,90 @@ describe('streamText', () => {
       expect(successCall.current.type).toBe('success');
       expect(successCall.current.model).toBe(fallbackModel);
       expect(successCall.attempts.length).toBe(1);
+    });
+  });
+
+  describe('onFailure', () => {
+    it('should call onFailure when the initial stream fails with no retry', async () => {
+      // Arrange
+      const baseModel = new MockLanguageModel({ doStream: nonRetryableError });
+      const onFailureSpy = vi.fn<OnFailure>();
+
+      // Act
+      const result = streamText({
+        model: createRetryable({
+          model: baseModel,
+          retries: [],
+          onFailure: onFailureSpy,
+        }),
+        prompt,
+      });
+      await convertAsyncIterableToArray(result.fullStream);
+
+      // Assert
+      expect(onFailureSpy).toHaveBeenCalledTimes(1);
+
+      const failureCall = onFailureSpy.mock.calls[0]![0];
+      expect(failureCall.current.type).toBe('error');
+      expect(failureCall.current.model).toBe(baseModel);
+      expect(failureCall.attempts.length).toBe(1);
+      expect(failureCall.error).toBe(nonRetryableError);
+    });
+
+    it('should call onFailure when a mid-stream error has no retry', async () => {
+      // Arrange
+      const baseModel = new MockLanguageModel({
+        doStream: mockStream(errorStreamChunks(nonRetryableError)),
+      });
+      const onFailureSpy = vi.fn<OnFailure>();
+
+      // Act
+      const result = streamText({
+        model: createRetryable({
+          model: baseModel,
+          retries: [],
+          onFailure: onFailureSpy,
+        }),
+        prompt,
+      });
+      const parts = await convertAsyncIterableToArray(result.fullStream);
+
+      // Assert
+      expect(errorFromChunks(parts)).toBe(nonRetryableError);
+      expect(onFailureSpy).toHaveBeenCalledTimes(1);
+
+      const failureCall = onFailureSpy.mock.calls[0]![0];
+      expect(failureCall.current.type).toBe('error');
+      expect(failureCall.current.model).toBe(baseModel);
+      expect(failureCall.attempts.length).toBe(1);
+      expect(failureCall.error).toBe(nonRetryableError);
+    });
+
+    it('should NOT call onFailure on a successful stream', async () => {
+      // Arrange
+      const baseModel = new MockLanguageModel({
+        doStream: {
+          stream: convertArrayToReadableStream(mockStreamChunks),
+        },
+      });
+      const onFailureSpy = vi.fn<OnFailure>();
+      const onSuccessSpy = vi.fn<OnSuccess>();
+
+      // Act
+      const result = streamText({
+        model: createRetryable({
+          model: baseModel,
+          retries: [],
+          onFailure: onFailureSpy,
+          onSuccess: onSuccessSpy,
+        }),
+        prompt,
+      });
+      await convertAsyncIterableToArray(result.fullStream);
+
+      // Assert
+      expect(onSuccessSpy).toHaveBeenCalledTimes(1);
+      expect(onFailureSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/internal/retryable-language-model.ts
+++ b/src/internal/retryable-language-model.ts
@@ -19,7 +19,11 @@ import type {
   RetryErrorAttempt,
   RetryResultAttempt,
 } from '../types.js';
-import { isGenerateResult, isStreamContentPart } from './guards.js';
+import {
+  isErrorAttempt,
+  isGenerateResult,
+  isStreamContentPart,
+} from './guards.js';
 
 export class RetryableLanguageModel
   extends BaseRetryableModel<LanguageModel>
@@ -343,6 +347,20 @@ export class RetryableLanguageModel
     return { retryModel, attempt: errorAttempt, finalError };
   }
 
+  /**
+   * Fire the `onFailure` callback for a terminally failed operation. The
+   * final attempt (last entry of `attempts`) is surfaced as `current`.
+   */
+  private emitFailure(
+    attempts: Array<RetryAttempt<LanguageModel>>,
+    error: unknown,
+  ) {
+    if (!this.options.onFailure) return;
+    const current = attempts.at(-1);
+    if (!current || !isErrorAttempt(current)) return;
+    this.options.onFailure({ current, attempts, error });
+  }
+
   async doGenerate(
     callOptions: LanguageModelCallOptions,
   ): Promise<LanguageModelResult> {
@@ -369,17 +387,19 @@ export class RetryableLanguageModel
       },
     );
 
+    /**
+     * Shared attempts array, threaded into `withRetry` so it stays populated
+     * (including the final failed attempt) when the retry loop throws.
+     */
+    const attempts: Array<RetryAttempt<LanguageModel>> = [];
     let operationError: unknown;
     try {
-      const {
-        result,
-        attempts,
-        callOptions: finalCallOptions,
-      } = await this.withRetry({
+      const { result, callOptions: finalCallOptions } = await this.withRetry({
         fn: async (retryCallOptions) => {
           return this.currentModel.doGenerate(retryCallOptions);
         },
         callOptions: callOptions,
+        attempts,
         recorder,
       });
 
@@ -398,6 +418,7 @@ export class RetryableLanguageModel
       return result;
     } catch (error) {
       operationError = error;
+      this.emitFailure(attempts, error);
       throw error;
     } finally {
       recorder?.endOperation({
@@ -438,7 +459,11 @@ export class RetryableLanguageModel
      * Perform the initial call to doStream with retry logic to handle errors before any data is streamed.
      */
     let result: LanguageModelStream;
-    let attempts: Array<RetryAttempt<LanguageModel>>;
+    /**
+     * Shared attempts array, threaded into `withRetry` so it stays populated
+     * (including the final failed attempt) when the retry loop throws.
+     */
+    let attempts: Array<RetryAttempt<LanguageModel>> = [];
     let finalCallOptions: LanguageModelCallOptions;
     /**
      * The open attempt span for the stream currently being consumed, closed
@@ -451,6 +476,7 @@ export class RetryableLanguageModel
           return this.currentModel.doStream(retryCallOptions);
         },
         callOptions: callOptions,
+        attempts,
         recorder,
       });
       result = initial.result;
@@ -462,6 +488,7 @@ export class RetryableLanguageModel
        * Every pre-stream attempt failed; record the operation failure before
        * the error propagates to the caller.
        */
+      this.emitFailure(attempts, error);
       recorder?.endOperation({
         provider: this.currentModel.provider,
         modelId: this.currentModel.modelId,
@@ -761,6 +788,7 @@ export class RetryableLanguageModel
                   });
                 }
                 operationError = finalError;
+                this.emitFailure(attempts, finalError);
                 controller.enqueue({ type: 'error', error: finalError });
                 controller.close();
                 return;
@@ -784,6 +812,7 @@ export class RetryableLanguageModel
                   });
                 }
                 operationError = error;
+                this.emitFailure(attempts, error);
                 controller.enqueue({ type: 'error', error });
                 controller.close();
                 return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,6 +217,29 @@ export type SuccessContext<
 };
 
 /**
+ * The context provided to onFailure when an operation terminally fails
+ * (no retry matched, retries exhausted, or the retry itself failed).
+ */
+export type FailureContext<
+  MODEL extends ResolvableLanguageModel | EmbeddingModel | ImageModel,
+> = {
+  /**
+   * The final attempt that failed.
+   */
+  current: RetryErrorAttempt<ResolvedModel<MODEL>>;
+  /**
+   * All attempts made, including the final failed one.
+   */
+  attempts: Array<RetryAttempt<ResolvedModel<MODEL>>>;
+  /**
+   * The error surfaced to the caller. When more than one attempt was made,
+   * this is a `RetryError` wrapping every attempt error; otherwise the raw
+   * error.
+   */
+  error: unknown;
+};
+
+/**
  * Telemetry configuration for retry instrumentation.
  *
  * Mirrors the AI SDK's `experimental_telemetry` shape so the two can be
@@ -291,6 +314,14 @@ export interface RetryableModelOptions<
     context: RetryContext<MODEL>,
   ) => void | OnRetryOverrides<MODEL> | Promise<void | OnRetryOverrides<MODEL>>;
   onSuccess?: (context: SuccessContext<MODEL>) => void;
+  /**
+   * Called once when an operation terminally fails and the error could not
+   * be recovered by a retry: no retry matched, all retries were exhausted,
+   * or the retry itself failed. The counterpart to `onSuccess`.
+   *
+   * Not called when retries are disabled.
+   */
+  onFailure?: (context: FailureContext<MODEL>) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `onFailure` callback, the terminal-failure counterpart to `onSuccess`. Invoked once when a request ultimately fails and no retry could recover it: no retryable matched, all retries were exhausted, or the retry itself failed. Not called when retries are disabled.
- Add `FailureContext` type: `current` (final failed attempt), `attempts` (all attempts), and `error` (the surfaced error, a `RetryError` wrapping every attempt error when more than one attempt was made, else the raw error).
- Wire it at every terminal-failure exit across all model types: language `doGenerate`, language `doStream` (pre-stream plus both mid-stream error-part paths), embedding `doEmbed`, and image `doGenerate`.
- Unify embedding/image `handleError` to return `finalError` (instead of throwing internally) so the final error attempt is always recorded in the shared attempts list, matching the language model. External behavior is unchanged (same errors thrown).
- Document `onFailure`/`FailureContext` in the README and add tests for all three model types.

## Test plan
- [x] `pnpm test` — 547 passing (new `onFailure` blocks: no-retry, retries-exhausted, success-doesn't-fire, success/failure symmetry, streaming pre-stream and mid-stream cases)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` / `oxfmt --check` — 0 errors, formatted
- [ ] Verify exactly one of `onSuccess`/`onFailure` fires per request, and `context.error` is a `RetryError` only when multiple attempts were made