### PR TITLE
feat(experimental): outcome callbacks for call-level retry drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,8 +977,6 @@ interface RetryCallCommitContext<MODEL> {
   current: {
     type: 'commit';
     model: MODEL;
-    /** Whatever the call function returned. Opaque: the driver never reads it. */
-    result: unknown;
     /** The per-attempt overrides, not full call options. */
     options: RetryCallOptions<MODEL>;
   };
@@ -986,7 +984,7 @@ interface RetryCallCommitContext<MODEL> {
 }
 ```
 
-`result` is `unknown` because the driver never inspects what the call function returned — the caller already has it typed from `run`'s return value. `options` holds only the per-attempt overrides, since the driver has no call options of its own (the call function owns the prompt). `onFailure` reuses the shared [`FailureContext`](#failurecontext) unchanged.
+It reports only what the driver itself knows. There is no `result`: the driver never inspects what the call function returned, and you already receive it, correctly typed, from `run`. `options` holds only the per-attempt overrides, since the driver has no call options of its own (the call function owns the prompt). `onFailure` reuses the shared [`FailureContext`](#failurecontext) unchanged.
 
 ### Deprecated: function-style retryables
 
@@ -1174,7 +1172,7 @@ interface SuccessContext<MODEL> {
 
 Passed to the `onSuccess` callback. `attempts` holds the preceding attempts that were retried, in order, and is empty when the first attempt succeeded. The successful attempt itself is `current` and is not repeated in `attempts`.
 
-The call-level drivers have their own [`RetryCallCommitContext`](#callbacks) instead, since their result is opaque.
+The call-level drivers have their own [`RetryCallCommitContext`](#callbacks) instead, which reports no result at all.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -935,13 +935,14 @@ The driver returns the call function's result unchanged, or throws the final err
 
 ##### Callbacks
 
-Both drivers take `onError` and `onRetry` exactly as the model wrappers do ([Logging](#logging)). The positive outcome is reported by **`onCommit`**, not `onSuccess`:
+Both drivers take `onError` and `onRetry` exactly as the model wrappers do ([Logging](#logging)), plus `onFailure`. The positive outcome is named for the boundary each one can actually observe — **`onComplete`** on `createRetryableCall`, **`onCommit`** on `createRetryableStream`:
 
 ```ts
 const run = createRetryableCall({
   model: primaryModel,
   retries: [timeout().switch({ model: fallbackModel })],
-  onCommit: (context) => {
+  /** The call function returned, so the driver stops retrying. */
+  onComplete: (context) => {
     console.log(
       `Handled by ${context.current.model.modelId} after ${context.attempts.length} failed attempts`,
     );
@@ -953,29 +954,37 @@ const run = createRetryableCall({
     );
   },
 });
+
+const runStream = createRetryableStream({
+  model: primaryModel,
+  retries: [timeout().switch({ model: fallbackModel })],
+  /** Same callback, later boundary: the first content part arrived. */
+  onCommit: (context) => {
+    console.log(`Streaming from ${context.current.model.modelId}`);
+  },
+});
 ```
 
-`onCommit` fires when an attempt **commits** — the driver has locked it in and will not fail over again. `onFailure` fires when the attempts are exhausted without committing: no retryable matched, every candidate was tried, the caller's signal was already aborted, or the caller aborted during a backoff delay. `context.error` is the error the run rejects with; `context.current` is the attempt that failed last.
+Neither name is `onSuccess`, because how much has to succeed before the call function returns is that function's choice, not the driver's:
+
+| Layer | Positive hook | Fires when | Operation finished? |
+| ----- | ------------- | ---------- | ------------------- |
+| `createRetryableCall` + `generateText` | `onComplete` | the call function returns | yes |
+| `createRetryableCall` + `streamText` | `onComplete` | the call function returns — the result object, before any content | no |
+| `createRetryableStream` | `onCommit` | the first content part reaches the stream | no, the body is still streaming |
+| `createRetryableModel` | `onSuccess` | the request completed, or the stream fully drained | yes |
+
+That middle row is why `createRetryableStream` exists: it moves the boundary to the last point anything can still fail over. A stream can commit and *then* error, get truncated by a `chunkMs` deadline, or finish with `content-filter` — none of which fires anything here, because the wrapper stopped being able to fail over at the commit point. For a hook that waits for the stream to actually finish, use the model wrapper's [`onSuccess`](#logging) underneath, or `streamText`'s own `onFinish`.
+
+`onFailure` fires when the attempts are exhausted without completing: no retryable matched, every candidate was tried, the caller's signal was already aborted, or the caller aborted during a backoff delay. `context.error` is the error the run rejects with; `context.current` is the attempt that failed last.
 
 Neither fires when retries are disabled. `onFailure` reports *attempt* failures, so it also stays silent for a rejection no attempt caused — one of your own callbacks throwing, or a retryable throwing before the first attempt was recorded. Those still reject the run; there is simply no failed attempt to hand over.
 
-Committing is not the same as the operation succeeding, which is why the hook is not called `onSuccess`. Where the boundary lands depends on the layer:
-
-| Layer | Commits when | Operation finished? |
-| ----- | ------------ | ------------------- |
-| `createRetryableCall` + `generateText` | the call function returns | yes |
-| `createRetryableCall` + `streamText` | the call function returns — the result object, before any content | no |
-| `createRetryableStream` | the first content part reaches the stream | no, the body is still streaming |
-| `createRetryableModel` (`onSuccess`) | the wrapped stream has fully drained | yes |
-
-So a stream can commit and still error, get truncated by a `chunkMs` deadline, or finish with `content-filter` afterwards — none of which fires anything here, because the driver stopped being able to fail over at the commit point. When you need a hook that waits for the stream to actually finish, use the model wrapper's [`onSuccess`](#logging) underneath, or `streamText`'s own `onFinish`.
-
-`onCommit` receives its own context type rather than the model-level [`SuccessContext`](#successcontext), since the driver knows less about the attempt than a model wrapper does:
+Both positive hooks share a context type, distinct from the model-level [`SuccessContext`](#successcontext) because the driver knows less about the attempt than a model wrapper does:
 
 ```ts
-interface RetryCallCommitContext<MODEL> {
+interface RetryCallCompleteContext<MODEL> {
   current: {
-    type: 'commit';
     model: MODEL;
     /** The per-attempt overrides, not full call options. */
     options: RetryCallOptions<MODEL>;
@@ -1172,7 +1181,7 @@ interface SuccessContext<MODEL> {
 
 Passed to the `onSuccess` callback. `attempts` holds the preceding attempts that were retried, in order, and is empty when the first attempt succeeded. The successful attempt itself is `current` and is not repeated in `attempts`.
 
-The call-level drivers have their own [`RetryCallCommitContext`](#callbacks) instead, which reports no result at all.
+The call-level drivers have their own [`RetryCallCompleteContext`](#callbacks) instead, which reports no result at all.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -891,6 +891,7 @@ for await (const chunk of result.textStream) console.log(chunk);
 - It is **error-based only**. Result-based conditions (`finishReason('content-filter')`, `schemaInvalid()`) recover best _below_ `streamText` and compose: pass a `createRetryableModel(...)` as the `model` and let this wrapper handle errors and timeouts around the call.
 - It also accepts a `streamObject` result (it reads `fullStream` when `stream` is absent).
 - The winning result is returned unchanged, so back-pressure past the commit point is preserved.
+- The callbacks follow the commit boundary: `onCommit` fires on the first content part, _not_ when the stream finishes, and `onFailure` fires when every attempt failed before committing. Past the commit point the stream is the caller's, so an error during consumption fires neither. See [Callbacks](#callbacks).
 
 #### `createRetryableCall`
 
@@ -931,6 +932,61 @@ Each attempt receives:
 - `attempt.attempt`: the 1-based attempt number.
 
 The driver returns the call function's result unchanged, or throws the final error (wrapped in a `RetryError` if more than one attempt was made). It is error-based only: a returned result is terminal and never re-evaluated.
+
+##### Callbacks
+
+Both drivers take `onError` and `onRetry` exactly as the model wrappers do ([Logging](#logging)). The positive outcome is reported by **`onCommit`**, not `onSuccess`:
+
+```ts
+const run = createRetryableCall({
+  model: primaryModel,
+  retries: [timeout().switch({ model: fallbackModel })],
+  onCommit: (context) => {
+    console.log(
+      `Handled by ${context.current.model.modelId} after ${context.attempts.length} failed attempts`,
+    );
+  },
+  onFailure: (context) => {
+    console.error(
+      `Failed after ${context.attempts.length} attempts:`,
+      context.error,
+    );
+  },
+});
+```
+
+`onCommit` fires when an attempt **commits** — the driver has locked it in and will not fail over again. `onFailure` fires when the attempts are exhausted without committing: no retryable matched, every candidate was tried, the caller's signal was already aborted, or the caller aborted during a backoff delay. `context.error` is the error the run rejects with; `context.current` is the attempt that failed last.
+
+Neither fires when retries are disabled. `onFailure` reports *attempt* failures, so it also stays silent for a rejection no attempt caused — one of your own callbacks throwing, or a retryable throwing before the first attempt was recorded. Those still reject the run; there is simply no failed attempt to hand over.
+
+Committing is not the same as the operation succeeding, which is why the hook is not called `onSuccess`. Where the boundary lands depends on the layer:
+
+| Layer | Commits when | Operation finished? |
+| ----- | ------------ | ------------------- |
+| `createRetryableCall` + `generateText` | the call function returns | yes |
+| `createRetryableCall` + `streamText` | the call function returns — the result object, before any content | no |
+| `createRetryableStream` | the first content part reaches the stream | no, the body is still streaming |
+| `createRetryableModel` (`onSuccess`) | the wrapped stream has fully drained | yes |
+
+So a stream can commit and still error, get truncated by a `chunkMs` deadline, or finish with `content-filter` afterwards — none of which fires anything here, because the driver stopped being able to fail over at the commit point. When you need a hook that waits for the stream to actually finish, use the model wrapper's [`onSuccess`](#logging) underneath, or `streamText`'s own `onFinish`.
+
+`onCommit` receives its own context type rather than the model-level [`SuccessContext`](#successcontext), since the driver knows less about the attempt than a model wrapper does:
+
+```ts
+interface RetryCallCommitContext<MODEL> {
+  current: {
+    type: 'commit';
+    model: MODEL;
+    /** Whatever the call function returned. Opaque: the driver never reads it. */
+    result: unknown;
+    /** The per-attempt overrides, not full call options. */
+    options: RetryCallOptions<MODEL>;
+  };
+  attempts: Array<RetryAttempt<MODEL>>;
+}
+```
+
+`result` is `unknown` because the driver never inspects what the call function returned — the caller already has it typed from `run`'s return value. `options` holds only the per-attempt overrides, since the driver has no call options of its own (the call function owns the prompt). `onFailure` reuses the shared [`FailureContext`](#failurecontext) unchanged.
 
 ### Deprecated: function-style retryables
 
@@ -1117,6 +1173,8 @@ interface SuccessContext<MODEL> {
 ```
 
 Passed to the `onSuccess` callback. `attempts` holds the preceding attempts that were retried, in order, and is empty when the first attempt succeeded. The successful attempt itself is `current` and is not repeated in `attempts`.
+
+The call-level drivers have their own [`RetryCallCommitContext`](#callbacks) instead, since their result is opaque.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -980,7 +980,7 @@ That middle row is why `createRetryableStream` exists: it moves the boundary to 
 
 Neither fires when retries are disabled. `onFailure` reports *attempt* failures, so it also stays silent for a rejection no attempt caused — one of your own callbacks throwing, or a retryable throwing before the first attempt was recorded. Those still reject the run; there is simply no failed attempt to hand over.
 
-Both positive hooks share a context type, distinct from the model-level [`SuccessContext`](#successcontext) because the driver knows less about the attempt than a model wrapper does:
+Each layer has its own context type — `RetryCallCompleteContext` and `RetryStreamCommitContext` — so neither API makes you import the other's vocabulary to type a callback. They are the same shape, and both are distinct from the model-level [`SuccessContext`](#successcontext) because the driver knows less about the attempt than a model wrapper does:
 
 ```ts
 interface RetryCallCompleteContext<MODEL> {
@@ -990,6 +990,12 @@ interface RetryCallCompleteContext<MODEL> {
     options: RetryCallOptions<MODEL>;
   };
   attempts: Array<RetryAttempt<MODEL>>;
+}
+
+/** The stream wrapper's equivalent, fixed to language models. */
+interface RetryStreamCommitContext {
+  current: { model: LanguageModel; options: RetryCallOptions<LanguageModel> };
+  attempts: Array<RetryAttempt<LanguageModel>>;
 }
 ```
 

--- a/src/experimental/call/create-retryable-call.test-d.ts
+++ b/src/experimental/call/create-retryable-call.test-d.ts
@@ -4,7 +4,12 @@ import {
   MockImageModel,
   MockLanguageModel,
 } from '../../internal/test-utils.js';
-import type { EmbeddingModel, ImageModel, LanguageModel } from '../../types.js';
+import type {
+  EmbeddingModel,
+  ImageModel,
+  LanguageModel,
+  RetryCallOptions,
+} from '../../types.js';
 import {
   createRetryableCall,
   type RetryCallAttempt,
@@ -37,6 +42,37 @@ describe('createRetryableCall types', () => {
     run((attempt) => {
       expectTypeOf(attempt.model).toEqualTypeOf<EmbeddingModel>();
       return Promise.resolve(0);
+    });
+  });
+
+  it('should type the commit context with an opaque result', () => {
+    // Act
+    createRetryableCall({
+      model: MockLanguageModel.from(),
+      retries: [],
+      onCommit: (context) => {
+        // Assert — the driver never inspects the result, hence `unknown`.
+        expectTypeOf(context.current.type).toEqualTypeOf<'commit'>();
+        expectTypeOf(context.current.model).toEqualTypeOf<LanguageModel>();
+        expectTypeOf(context.current.result).toEqualTypeOf<unknown>();
+        expectTypeOf(context.current.options).toEqualTypeOf<
+          RetryCallOptions<LanguageModel>
+        >();
+      },
+    });
+  });
+
+  it('should type the failure context with the final error attempt', () => {
+    // Act
+    createRetryableCall({
+      model: MockLanguageModel.from(),
+      retries: [],
+      onFailure: (context) => {
+        // Assert
+        expectTypeOf(context.current.type).toEqualTypeOf<'error'>();
+        expectTypeOf(context.current.model).toEqualTypeOf<LanguageModel>();
+        expectTypeOf(context.error).toEqualTypeOf<unknown>();
+      },
     });
   });
 

--- a/src/experimental/call/create-retryable-call.test-d.ts
+++ b/src/experimental/call/create-retryable-call.test-d.ts
@@ -45,19 +45,19 @@ describe('createRetryableCall types', () => {
     });
   });
 
-  it('should type the commit context with an opaque result', () => {
+  it('should type the commit context with what the driver knows', () => {
     // Act
     createRetryableCall({
       model: MockLanguageModel.from(),
       retries: [],
       onCommit: (context) => {
-        // Assert — the driver never inspects the result, hence `unknown`.
+        // Assert — only what the driver itself knows about the attempt.
         expectTypeOf(context.current.type).toEqualTypeOf<'commit'>();
         expectTypeOf(context.current.model).toEqualTypeOf<LanguageModel>();
-        expectTypeOf(context.current.result).toEqualTypeOf<unknown>();
         expectTypeOf(context.current.options).toEqualTypeOf<
           RetryCallOptions<LanguageModel>
         >();
+        expectTypeOf(context.current).not.toHaveProperty('result');
       },
     });
   });

--- a/src/experimental/call/create-retryable-call.test-d.ts
+++ b/src/experimental/call/create-retryable-call.test-d.ts
@@ -45,14 +45,13 @@ describe('createRetryableCall types', () => {
     });
   });
 
-  it('should type the commit context with what the driver knows', () => {
+  it('should type the completion context with what the driver knows', () => {
     // Act
     createRetryableCall({
       model: MockLanguageModel.from(),
       retries: [],
-      onCommit: (context) => {
+      onComplete: (context) => {
         // Assert — only what the driver itself knows about the attempt.
-        expectTypeOf(context.current.type).toEqualTypeOf<'commit'>();
         expectTypeOf(context.current.model).toEqualTypeOf<LanguageModel>();
         expectTypeOf(context.current.options).toEqualTypeOf<
           RetryCallOptions<LanguageModel>

--- a/src/experimental/call/create-retryable-call.test.ts
+++ b/src/experimental/call/create-retryable-call.test.ts
@@ -467,13 +467,14 @@ describe('createRetryableCall', () => {
       });
 
       // Act
-      await run(fn);
+      const returned = await run(fn);
 
-      // Assert
+      // Assert — the result reaches the caller, not the hook.
+      expect(returned).toBe('OK');
       expect(onCommit).toHaveBeenCalledTimes(1);
       expect(onCommit.mock.calls[0]![0].current.type).toBe('commit');
       expect(onCommit.mock.calls[0]![0].current.model).toBe(primary);
-      expect(onCommit.mock.calls[0]![0].current.result).toBe('OK');
+      expect('result' in onCommit.mock.calls[0]![0].current).toBe(false);
       expect(onCommit.mock.calls[0]![0].attempts.length).toBe(0);
     });
 
@@ -490,12 +491,12 @@ describe('createRetryableCall', () => {
       });
 
       // Act
-      await run(fn);
+      const returned = await run(fn);
 
       // Assert — the failed attempt precedes the successful one.
+      expect(returned).toBe('FALLBACK_OK');
       expect(onCommit).toHaveBeenCalledTimes(1);
       expect(onCommit.mock.calls[0]![0].current.model).toBe(fallback);
-      expect(onCommit.mock.calls[0]![0].current.result).toBe('FALLBACK_OK');
       expect(onCommit.mock.calls[0]![0].attempts.length).toBe(1);
       expect(onCommit.mock.calls[0]![0].attempts[0].model).toBe(primary);
     });

--- a/src/experimental/call/create-retryable-call.test.ts
+++ b/src/experimental/call/create-retryable-call.test.ts
@@ -454,16 +454,16 @@ describe('createRetryableCall', () => {
     });
   });
 
-  describe('onCommit', () => {
-    it('should call onCommit when the first attempt succeeds', async () => {
+  describe('onComplete', () => {
+    it('should call onComplete when the first attempt succeeds', async () => {
       // Arrange
       const primary = MockLanguageModel.from();
-      const onCommit = vi.fn();
+      const onComplete = vi.fn();
       const fn = vi.fn(async (_attempt: RetryCallAttempt) => 'OK');
       const run = createRetryableCall({
         model: primary,
         retries: [],
-        onCommit,
+        onComplete,
       });
 
       // Act
@@ -471,23 +471,22 @@ describe('createRetryableCall', () => {
 
       // Assert — the result reaches the caller, not the hook.
       expect(returned).toBe('OK');
-      expect(onCommit).toHaveBeenCalledTimes(1);
-      expect(onCommit.mock.calls[0]![0].current.type).toBe('commit');
-      expect(onCommit.mock.calls[0]![0].current.model).toBe(primary);
-      expect('result' in onCommit.mock.calls[0]![0].current).toBe(false);
-      expect(onCommit.mock.calls[0]![0].attempts.length).toBe(0);
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      expect(onComplete.mock.calls[0]![0].current.model).toBe(primary);
+      expect('result' in onComplete.mock.calls[0]![0].current).toBe(false);
+      expect(onComplete.mock.calls[0]![0].attempts.length).toBe(0);
     });
 
-    it('should call onCommit with the model that recovered the call', async () => {
+    it('should call onComplete with the model that recovered the call', async () => {
       // Arrange
       const primary = MockLanguageModel.from();
       const fallback = MockLanguageModel.from();
-      const onCommit = vi.fn();
+      const onComplete = vi.fn();
       const fn = failOn([primary], 'FALLBACK_OK');
       const run = createRetryableCall({
         model: primary,
         retries: [fallback],
-        onCommit,
+        onComplete,
       });
 
       // Act
@@ -495,69 +494,71 @@ describe('createRetryableCall', () => {
 
       // Assert — the failed attempt precedes the successful one.
       expect(returned).toBe('FALLBACK_OK');
-      expect(onCommit).toHaveBeenCalledTimes(1);
-      expect(onCommit.mock.calls[0]![0].current.model).toBe(fallback);
-      expect(onCommit.mock.calls[0]![0].attempts.length).toBe(1);
-      expect(onCommit.mock.calls[0]![0].attempts[0].model).toBe(primary);
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      expect(onComplete.mock.calls[0]![0].current.model).toBe(fallback);
+      expect(onComplete.mock.calls[0]![0].attempts.length).toBe(1);
+      expect(onComplete.mock.calls[0]![0].attempts[0].model).toBe(primary);
     });
 
-    it('should expose the committed attempt options on the context', async () => {
+    it('should expose the final attempt options on the context', async () => {
       // Arrange
       const primary = MockLanguageModel.from();
       const fallback = MockLanguageModel.from();
-      const onCommit = vi.fn();
+      const onComplete = vi.fn();
       const fn = failOn([primary]);
       const run = createRetryableCall({
         model: primary,
         retries: [{ model: fallback, options: { temperature: 0.5 } }],
-        onCommit,
+        onComplete,
       });
 
       // Act
       await run(fn);
 
       // Assert
-      expect(onCommit.mock.calls[0]![0].current.options.temperature).toBe(0.5);
+      expect(onComplete.mock.calls[0]![0].current.options.temperature).toBe(
+        0.5,
+      );
     });
 
-    it('should NOT call onCommit when every attempt fails', async () => {
+    it('should NOT call onComplete when every attempt fails', async () => {
       // Arrange
       const primary = MockLanguageModel.from();
       const fallback = MockLanguageModel.from();
-      const onCommit = vi.fn();
+      const onComplete = vi.fn();
       const fn = vi.fn(async () => {
         throw new Error('always fails');
       });
       const run = createRetryableCall({
         model: primary,
         retries: [fallback],
-        onCommit,
+        onComplete,
       });
 
       // Act
       await run(fn).catch(() => {});
 
       // Assert
-      expect(onCommit).toHaveBeenCalledTimes(0);
+      expect(onComplete).toHaveBeenCalledTimes(0);
     });
 
-    it('should NOT call onCommit when retries are disabled', async () => {
+    it('should NOT call onComplete when retries are disabled', async () => {
       // Arrange
       const primary = MockLanguageModel.from();
-      const onCommit = vi.fn();
+      const onComplete = vi.fn();
       const fn = vi.fn(async (_attempt: RetryCallAttempt) => 'OK');
       const run = createRetryableCall({
         model: primary,
         retries: [],
         disabled: true,
-        onCommit,
+        onComplete,
       });
 
       // Act
       await run(fn);
 
       // Assert
-      expect(onCommit).toHaveBeenCalledTimes(0);
+      expect(onComplete).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -646,7 +647,7 @@ describe('createRetryableCall', () => {
       const primary = MockLanguageModel.from();
       const fallback = MockLanguageModel.from();
       const controller = new AbortController();
-      const onCommit = vi.fn();
+      const onComplete = vi.fn();
       const onFailure = vi.fn();
       const fn = vi.fn(async () => {
         setTimeout(() => controller.abort(), 10);
@@ -655,7 +656,7 @@ describe('createRetryableCall', () => {
       const run = createRetryableCall({
         model: primary,
         retries: [{ model: fallback, delay: 200 }],
-        onCommit,
+        onComplete,
         onFailure,
       });
 
@@ -665,7 +666,7 @@ describe('createRetryableCall', () => {
       // Assert
       await expect(result).rejects.toThrow();
       expect(fn).toHaveBeenCalledTimes(1);
-      expect(onCommit).toHaveBeenCalledTimes(0);
+      expect(onComplete).toHaveBeenCalledTimes(0);
       expect(onFailure).toHaveBeenCalledTimes(1);
       expect(onFailure.mock.calls[0]![0].attempts.length).toBe(1);
     });
@@ -695,18 +696,18 @@ describe('createRetryableCall', () => {
       expect(onFailure.mock.calls[0]![0].error).toBe(handlerError);
     });
 
-    it('should NOT re-run a committed call when an onCommit handler throws', async () => {
+    it('should NOT re-run a completed call when an onComplete handler throws', async () => {
       // Arrange — a throwing hook must not look like a failed attempt, or the
       // driver would fail over and issue the call a second time.
       const primary = MockLanguageModel.from();
       const fallback = MockLanguageModel.from();
-      const handlerError = new Error('onCommit blew up');
+      const handlerError = new Error('onComplete blew up');
       const onFailure = vi.fn();
       const fn = vi.fn(async (_attempt: RetryCallAttempt) => 'OK');
       const run = createRetryableCall({
         model: primary,
         retries: [fallback],
-        onCommit: () => {
+        onComplete: () => {
           throw handlerError;
         },
         onFailure,

--- a/src/experimental/call/create-retryable-call.test.ts
+++ b/src/experimental/call/create-retryable-call.test.ts
@@ -454,6 +454,345 @@ describe('createRetryableCall', () => {
     });
   });
 
+  describe('onCommit', () => {
+    it('should call onCommit when the first attempt succeeds', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const onCommit = vi.fn();
+      const fn = vi.fn(async (_attempt: RetryCallAttempt) => 'OK');
+      const run = createRetryableCall({
+        model: primary,
+        retries: [],
+        onCommit,
+      });
+
+      // Act
+      await run(fn);
+
+      // Assert
+      expect(onCommit).toHaveBeenCalledTimes(1);
+      expect(onCommit.mock.calls[0]![0].current.type).toBe('commit');
+      expect(onCommit.mock.calls[0]![0].current.model).toBe(primary);
+      expect(onCommit.mock.calls[0]![0].current.result).toBe('OK');
+      expect(onCommit.mock.calls[0]![0].attempts.length).toBe(0);
+    });
+
+    it('should call onCommit with the model that recovered the call', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const fallback = MockLanguageModel.from();
+      const onCommit = vi.fn();
+      const fn = failOn([primary], 'FALLBACK_OK');
+      const run = createRetryableCall({
+        model: primary,
+        retries: [fallback],
+        onCommit,
+      });
+
+      // Act
+      await run(fn);
+
+      // Assert — the failed attempt precedes the successful one.
+      expect(onCommit).toHaveBeenCalledTimes(1);
+      expect(onCommit.mock.calls[0]![0].current.model).toBe(fallback);
+      expect(onCommit.mock.calls[0]![0].current.result).toBe('FALLBACK_OK');
+      expect(onCommit.mock.calls[0]![0].attempts.length).toBe(1);
+      expect(onCommit.mock.calls[0]![0].attempts[0].model).toBe(primary);
+    });
+
+    it('should expose the committed attempt options on the context', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const fallback = MockLanguageModel.from();
+      const onCommit = vi.fn();
+      const fn = failOn([primary]);
+      const run = createRetryableCall({
+        model: primary,
+        retries: [{ model: fallback, options: { temperature: 0.5 } }],
+        onCommit,
+      });
+
+      // Act
+      await run(fn);
+
+      // Assert
+      expect(onCommit.mock.calls[0]![0].current.options.temperature).toBe(0.5);
+    });
+
+    it('should NOT call onCommit when every attempt fails', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const fallback = MockLanguageModel.from();
+      const onCommit = vi.fn();
+      const fn = vi.fn(async () => {
+        throw new Error('always fails');
+      });
+      const run = createRetryableCall({
+        model: primary,
+        retries: [fallback],
+        onCommit,
+      });
+
+      // Act
+      await run(fn).catch(() => {});
+
+      // Assert
+      expect(onCommit).toHaveBeenCalledTimes(0);
+    });
+
+    it('should NOT call onCommit when retries are disabled', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const onCommit = vi.fn();
+      const fn = vi.fn(async (_attempt: RetryCallAttempt) => 'OK');
+      const run = createRetryableCall({
+        model: primary,
+        retries: [],
+        disabled: true,
+        onCommit,
+      });
+
+      // Act
+      await run(fn);
+
+      // Assert
+      expect(onCommit).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('onFailure', () => {
+    it('should call onFailure with the original error when no retryable matches', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const error = new Error('boom');
+      const onFailure = vi.fn();
+      const fn = vi.fn(async () => {
+        throw error;
+      });
+      const run = createRetryableCall({
+        model: primary,
+        retries: [],
+        onFailure,
+      });
+
+      // Act
+      await run(fn).catch(() => {});
+
+      // Assert
+      expect(onFailure).toHaveBeenCalledTimes(1);
+      expect(onFailure.mock.calls[0]![0].error).toBe(error);
+      expect(onFailure.mock.calls[0]![0].current.type).toBe('error');
+      expect(onFailure.mock.calls[0]![0].current.error).toBe(error);
+      expect(onFailure.mock.calls[0]![0].current.model).toBe(primary);
+      expect(onFailure.mock.calls[0]![0].attempts.length).toBe(1);
+    });
+
+    it('should call onFailure with a RetryError once retries are exhausted', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const fallback = MockLanguageModel.from();
+      const onFailure = vi.fn();
+      const fn = vi.fn(async () => {
+        throw new Error('always fails');
+      });
+      const run = createRetryableCall({
+        model: primary,
+        retries: [fallback],
+        onFailure,
+      });
+
+      // Act
+      await run(fn).catch(() => {});
+
+      // Assert — the final attempt is the fallback's.
+      expect(onFailure).toHaveBeenCalledTimes(1);
+      expect(RetryError.isInstance(onFailure.mock.calls[0]![0].error)).toBe(
+        true,
+      );
+      expect(onFailure.mock.calls[0]![0].current.model).toBe(fallback);
+      expect(onFailure.mock.calls[0]![0].attempts.length).toBe(2);
+    });
+
+    it('should call onFailure when the caller aborts before the retry fires', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const fallback = MockLanguageModel.from();
+      const controller = new AbortController();
+      const error = new Error('primary failed');
+      const onFailure = vi.fn();
+      const fn = vi.fn(async () => {
+        controller.abort();
+        throw error;
+      });
+      const run = createRetryableCall({
+        model: primary,
+        retries: [fallback],
+        onFailure,
+      });
+
+      // Act
+      await run(fn, { abortSignal: controller.signal }).catch(() => {});
+
+      // Assert — the retry is skipped, so the raw error is surfaced.
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(onFailure).toHaveBeenCalledTimes(1);
+      expect(onFailure.mock.calls[0]![0].error).toBe(error);
+    });
+
+    it('should call onFailure when the caller aborts during the backoff delay', async () => {
+      // Arrange — the abort lands while the retry is waiting out its delay,
+      // after the failed attempt has already been recorded.
+      const primary = MockLanguageModel.from();
+      const fallback = MockLanguageModel.from();
+      const controller = new AbortController();
+      const onCommit = vi.fn();
+      const onFailure = vi.fn();
+      const fn = vi.fn(async () => {
+        setTimeout(() => controller.abort(), 10);
+        throw new Error('primary failed');
+      });
+      const run = createRetryableCall({
+        model: primary,
+        retries: [{ model: fallback, delay: 200 }],
+        onCommit,
+        onFailure,
+      });
+
+      // Act
+      const result = run(fn, { abortSignal: controller.signal });
+
+      // Assert
+      await expect(result).rejects.toThrow();
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(onCommit).toHaveBeenCalledTimes(0);
+      expect(onFailure).toHaveBeenCalledTimes(1);
+      expect(onFailure.mock.calls[0]![0].attempts.length).toBe(1);
+    });
+
+    it('should call onFailure when an onRetry handler throws', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const fallback = MockLanguageModel.from();
+      const handlerError = new Error('onRetry blew up');
+      const onFailure = vi.fn();
+      const fn = failOn([primary]);
+      const run = createRetryableCall({
+        model: primary,
+        retries: [fallback],
+        onRetry: () => {
+          throw handlerError;
+        },
+        onFailure,
+      });
+
+      // Act
+      const result = run(fn);
+
+      // Assert — the handler error escapes the loop and is still reported.
+      await expect(result).rejects.toThrow();
+      expect(onFailure).toHaveBeenCalledTimes(1);
+      expect(onFailure.mock.calls[0]![0].error).toBe(handlerError);
+    });
+
+    it('should NOT re-run a committed call when an onCommit handler throws', async () => {
+      // Arrange — a throwing hook must not look like a failed attempt, or the
+      // driver would fail over and issue the call a second time.
+      const primary = MockLanguageModel.from();
+      const fallback = MockLanguageModel.from();
+      const handlerError = new Error('onCommit blew up');
+      const onFailure = vi.fn();
+      const fn = vi.fn(async (_attempt: RetryCallAttempt) => 'OK');
+      const run = createRetryableCall({
+        model: primary,
+        retries: [fallback],
+        onCommit: () => {
+          throw handlerError;
+        },
+        onFailure,
+      });
+
+      // Act
+      const result = run(fn);
+
+      // Assert — one call only; the handler error surfaces unwrapped. No
+      // onFailure: nothing about the attempt failed, so there is no failed
+      // attempt to report as `current`.
+      await expect(result).rejects.toThrow();
+      await result.catch((e) => expect(e).toBe(handlerError));
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(onFailure).toHaveBeenCalledTimes(0);
+    });
+
+    it('should NOT call onFailure when a retryable throws on the first attempt', async () => {
+      // Arrange — documents a coverage gap: the attempt is only recorded once
+      // the retryables have been evaluated, so a retryable that throws leaves
+      // nothing to report as the failed attempt.
+      const primary = MockLanguageModel.from();
+      const retryableError = new Error('retryable blew up');
+      const onFailure = vi.fn();
+      const fn = vi.fn(async () => {
+        throw new Error('primary failed');
+      });
+      const run = createRetryableCall({
+        model: primary,
+        retries: [
+          () => {
+            throw retryableError;
+          },
+        ],
+        onFailure,
+      });
+
+      // Act
+      const result = run(fn);
+
+      // Assert — the run still rejects with the retryable's error.
+      await expect(result).rejects.toThrow();
+      await result.catch((e) => expect(e).toBe(retryableError));
+      expect(onFailure).toHaveBeenCalledTimes(0);
+    });
+
+    it('should NOT call onFailure when the call succeeds', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const fallback = MockLanguageModel.from();
+      const onFailure = vi.fn();
+      const fn = failOn([primary]);
+      const run = createRetryableCall({
+        model: primary,
+        retries: [fallback],
+        onFailure,
+      });
+
+      // Act
+      await run(fn);
+
+      // Assert
+      expect(onFailure).toHaveBeenCalledTimes(0);
+    });
+
+    it('should NOT call onFailure when retries are disabled', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const onFailure = vi.fn();
+      const fn = vi.fn(async () => {
+        throw new Error('boom');
+      });
+      const run = createRetryableCall({
+        model: primary,
+        retries: [],
+        disabled: true,
+        onFailure,
+      });
+
+      // Act
+      await run(fn).catch(() => {});
+
+      // Assert
+      expect(onFailure).toHaveBeenCalledTimes(0);
+    });
+  });
+
   describe('attempt', () => {
     it('should expose the model and a 1-based attempt number', async () => {
       // Arrange

--- a/src/experimental/call/create-retryable-call.ts
+++ b/src/experimental/call/create-retryable-call.ts
@@ -85,17 +85,16 @@ export type RetryCallRunOptions = {
  * The attempt the driver committed to: the one whose call function returned,
  * after which no further fail-over is possible.
  *
- * Deliberately distinct from the model-level `SuccessAttempt`. That one carries
- * a model result and full call options; here the result is whatever the call
- * function returned (opaque to the driver) and the options are only the
- * per-attempt overrides, since the driver has no call options of its own.
+ * Deliberately distinct from the model-level `SuccessAttempt`, which carries a
+ * model result and full call options. Neither has an equivalent here: the
+ * result is the call function's own and reaches the caller through `run`, and
+ * the options are only the per-attempt overrides, since the driver has no call
+ * options of its own.
  */
 export type RetryCallCommitAttempt<MODEL extends AnyModel = LanguageModel> = {
   type: 'commit';
   /** The model whose attempt committed. */
   model: MODEL;
-  /** Whatever the call function returned. Opaque: the driver never reads it. */
-  result: unknown;
   /** The per-attempt overrides applied to the committed attempt. */
   options: RetryCallOptions<MODEL>;
 };
@@ -166,17 +165,16 @@ export interface RetryableCallOptions<MODEL extends AnyModel = LanguageModel> {
    * has locked that attempt in and will not fail over again. Reports the model
    * that handled it and the attempts that were retried before it.
    *
-   * Deliberately not named `onSuccess`, because committing is not the same as
-   * the operation succeeding. The call function decides how much has to happen
-   * before it returns: a `generateText` call has fully completed by then, but a
-   * `streamText` call has only produced its result object, and whatever it goes
-   * on to stream (or fail with) is past the driver's reach. The stream wrapper
-   * moves the boundary to the first content part, which is as far as anything
-   * can fail over.
+   * Not named `onSuccess`, because how much has to succeed before the call
+   * function returns is the call function's choice, not the driver's. A
+   * `generateText` call has fully completed by then; a `streamText` call has
+   * only produced its result object, and whatever it goes on to stream — or
+   * fail with — is past the driver's reach. The stream wrapper moves the
+   * boundary to the first content part, which is as late as anything can still
+   * fail over.
    *
-   * `current.result` is whatever the call function returned. The driver never
-   * inspects it, so it is typed `unknown`; the caller already has it typed
-   * from `run`'s return value.
+   * The result is not reported here: the driver never inspects it, and the
+   * caller receives it, correctly typed, from `run`.
    */
   onCommit?: (context: RetryCallCommitContext<MODEL>) => void;
   /**
@@ -464,7 +462,7 @@ class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
         this.updateStickyModel(startModel);
 
         this.emitCommit(
-          { type: 'commit', model: attemptModel, result, options },
+          { type: 'commit', model: attemptModel, options },
           attempts,
         );
 

--- a/src/experimental/call/create-retryable-call.ts
+++ b/src/experimental/call/create-retryable-call.ts
@@ -1,12 +1,14 @@
 import { delay } from '@ai-sdk/provider-utils';
 import { BaseRetryableModel } from '../../internal/base-retryable-model.js';
 import { evaluateError } from '../../internal/evaluate-error.js';
+import { isErrorAttempt } from '../../internal/guards.js';
 import { resolveBackoffDelay } from '../../internal/resolve-backoff-delay.js';
 import { resolveModel } from '../../internal/resolve-model.js';
 import { createRetryTelemetry } from '../../internal/telemetry.js';
 import type {
   CallOptions,
   EmbeddingModel,
+  FailureContext,
   ImageModel,
   LanguageModel,
   OnRetryOverrides,
@@ -80,6 +82,40 @@ export type RetryCallRunOptions = {
 };
 
 /**
+ * The attempt the driver committed to: the one whose call function returned,
+ * after which no further fail-over is possible.
+ *
+ * Deliberately distinct from the model-level `SuccessAttempt`. That one carries
+ * a model result and full call options; here the result is whatever the call
+ * function returned (opaque to the driver) and the options are only the
+ * per-attempt overrides, since the driver has no call options of its own.
+ */
+export type RetryCallCommitAttempt<MODEL extends AnyModel = LanguageModel> = {
+  type: 'commit';
+  /** The model whose attempt committed. */
+  model: MODEL;
+  /** Whatever the call function returned. Opaque: the driver never reads it. */
+  result: unknown;
+  /** The per-attempt overrides applied to the committed attempt. */
+  options: RetryCallOptions<MODEL>;
+};
+
+/**
+ * The context passed to `onCommit`, with the committed attempt and the
+ * attempts that were retried before it.
+ */
+export type RetryCallCommitContext<MODEL extends AnyModel = LanguageModel> = {
+  /** The attempt that committed. */
+  current: RetryCallCommitAttempt<MODEL>;
+  /**
+   * The preceding attempts that were retried, in order. Empty when the first
+   * attempt committed. The committed attempt is `current` and is not repeated
+   * here.
+   */
+  attempts: Array<RetryAttempt<MODEL>>;
+};
+
+/**
  * The driver returned by {@link createRetryableCall}. Invoke it with a function
  * that performs one attempt; it loops over the configured retries until the
  * function returns (the result is passed through unchanged) or no retry
@@ -95,8 +131,7 @@ export type RetryCall<MODEL extends AnyModel = LanguageModel> = <RESULT>(
  * Options for {@link createRetryableCall}.
  *
  * Mirrors the subset of `RetryableModelOptions` that applies to a generic
- * retry loop. There is no `onSuccess` here because the result is opaque to the
- * driver; the caller observes success directly from `run`'s return value.
+ * retry loop.
  */
 export interface RetryableCallOptions<MODEL extends AnyModel = LanguageModel> {
   /** Base model used for the first attempt (resolved on first use). */
@@ -126,7 +161,48 @@ export interface RetryableCallOptions<MODEL extends AnyModel = LanguageModel> {
   onRetry?: (
     context: RetryContext<MODEL>,
   ) => void | OnRetryOverrides<MODEL> | Promise<void | OnRetryOverrides<MODEL>>;
+  /**
+   * Called once an attempt commits: the call function returned, so the driver
+   * has locked that attempt in and will not fail over again. Reports the model
+   * that handled it and the attempts that were retried before it.
+   *
+   * Deliberately not named `onSuccess`, because committing is not the same as
+   * the operation succeeding. The call function decides how much has to happen
+   * before it returns: a `generateText` call has fully completed by then, but a
+   * `streamText` call has only produced its result object, and whatever it goes
+   * on to stream (or fail with) is past the driver's reach. The stream wrapper
+   * moves the boundary to the first content part, which is as far as anything
+   * can fail over.
+   *
+   * `current.result` is whatever the call function returned. The driver never
+   * inspects it, so it is typed `unknown`; the caller already has it typed
+   * from `run`'s return value.
+   */
+  onCommit?: (context: RetryCallCommitContext<MODEL>) => void;
+  /**
+   * Called once when the attempts are exhausted without committing: no retry
+   * matched, every candidate was tried, the caller's signal was already
+   * aborted, or the caller aborted during a backoff delay. `context.error` is
+   * the error the run rejects with, and `context.current` the attempt that
+   * failed last. The counterpart to `onCommit`.
+   *
+   * Reports attempt failures, so it stays silent for a rejection that no
+   * attempt caused — a callback of your own throwing, or a retryable throwing
+   * before the first attempt was recorded. Those still reject the run; there
+   * is simply no failed attempt to hand over. Also silent when retries are
+   * disabled.
+   */
+  onFailure?: (context: FailureContext<MODEL>) => void;
 }
+
+/**
+ * {@link RetryableCallOptions} once the base model has been resolved from its
+ * gateway-string form to an instance.
+ */
+type ResolvedCallOptions<MODEL extends AnyModel> = Omit<
+  RetryableCallOptions<MODEL>,
+  'model'
+> & { model: MODEL };
 
 /**
  * Resolve the per-attempt option overrides handed to the call function.
@@ -169,6 +245,48 @@ function resolveRetryOptions<MODEL extends AnyModel>(
  * already absorb internally.
  */
 class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
+  /**
+   * The options under their call-level types. `BaseRetryableModel` stores them
+   * under the model-level ones, which have no `onCommit` at all, so this is the
+   * handle the loop reads the hooks through.
+   */
+  private readonly callOptions: ResolvedCallOptions<MODEL>;
+
+  constructor(options: ResolvedCallOptions<MODEL>) {
+    super(options as unknown as RetryableModelOptions<MODEL>);
+    this.callOptions = options;
+  }
+
+  /**
+   * Fire the `onCommit` callback for a call that returned.
+   *
+   * No cast, unlike {@link RetryableCall.emitFailure}: the commit context is
+   * declared over `MODEL` directly, whereas the shared contexts are declared
+   * over `ResolvedModel<MODEL>` — the same type at runtime, but not provably so
+   * for a generic `MODEL`.
+   */
+  private emitCommit(
+    current: RetryCallCommitAttempt<MODEL>,
+    attempts: Array<RetryAttempt<MODEL>>,
+  ) {
+    this.callOptions.onCommit?.({ current, attempts });
+  }
+
+  /**
+   * Fire the `onFailure` callback for a terminally failed call. The final
+   * attempt (last entry of `attempts`) is surfaced as `current`.
+   */
+  private emitFailure(attempts: Array<RetryAttempt<MODEL>>, error: unknown) {
+    if (!this.callOptions.onFailure) return;
+    const current = attempts.at(-1);
+    if (!current || !isErrorAttempt(current)) return;
+    this.callOptions.onFailure({
+      current,
+      attempts,
+      error,
+    } as unknown as FailureContext<MODEL>);
+  }
+
   async run<RESULT>(
     fn: (attempt: RetryCallAttempt<MODEL>) => Promise<RESULT>,
     runOptions?: RetryCallRunOptions,
@@ -235,7 +353,7 @@ class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
           } as unknown as RetryContext<MODEL>;
 
           onRetryOverrides =
-            (await this.options.onRetry?.(context)) ?? undefined;
+            (await this.callOptions.onRetry?.(context)) ?? undefined;
         }
 
         const attemptModel = this.currentModel;
@@ -257,18 +375,21 @@ class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
           timeoutMs: attemptTimeout,
         });
 
+        /**
+         * Only the call itself is guarded. Everything that runs once the
+         * attempt has committed stays outside, so a throwing `onCommit`
+         * handler cannot be mistaken for a failed attempt and re-run a call
+         * that already succeeded.
+         */
+        let result: RESULT;
         try {
-          const result = await fn({
+          result = await fn({
             model: attemptModel,
             attempt: attemptNumber,
             timeout: attemptTimeout,
             abortSignal: runOptions?.abortSignal,
             options,
           });
-
-          recorder?.endAttempt({ attempt: attemptNumber, outcome: 'success' });
-          this.updateStickyModel(startModel);
-          return result;
         } catch (error) {
           /**
            * Evaluate the failure. `options` is a minimal placeholder: the
@@ -284,7 +405,7 @@ class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
             } as CallOptions<MODEL>,
             attempts,
             retries: this.options.retries,
-            onError: this.options.onError,
+            onError: this.callOptions.onError,
           });
 
           const retryModel = evaluation.retryModel as Retry<MODEL> | undefined;
@@ -302,7 +423,6 @@ class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
               outcome: 'failure',
               error,
             });
-            operationError = finalError;
             throw finalError;
           }
 
@@ -317,7 +437,6 @@ class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
               outcome: 'failure',
               error,
             });
-            operationError = error;
             throw error;
           }
 
@@ -338,8 +457,30 @@ class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
 
           this.currentModel = retryModel.model;
           currentRetry = retryModel;
+          continue;
         }
+
+        recorder?.endAttempt({ attempt: attemptNumber, outcome: 'success' });
+        this.updateStickyModel(startModel);
+
+        this.emitCommit(
+          { type: 'commit', model: attemptModel, result, options },
+          attempts,
+        );
+
+        return result;
       }
+    } catch (error) {
+      /**
+       * Every way the loop can end without committing lands here: no retry
+       * matched, the caller's signal was already aborted, the caller aborted
+       * during a backoff delay, or a caller-supplied handler threw. Reporting
+       * once at the boundary is what makes it impossible to reject without
+       * telling `onFailure` and the operation span about it.
+       */
+      operationError = error;
+      this.emitFailure(attempts, error);
+      throw error;
     } finally {
       recorder?.endOperation({
         provider: this.currentModel.provider,
@@ -366,11 +507,11 @@ class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
 export function createRetryableCall<MODEL extends AnyModel = LanguageModel>(
   options: RetryableCallOptions<MODEL>,
 ): RetryCall<MODEL> {
-  const model = resolveModel(options.model);
+  const model = resolveModel(options.model) as unknown as MODEL;
   const instance = new RetryableCall<MODEL>({
     ...options,
     model,
-  } as unknown as RetryableModelOptions<MODEL>);
+  });
 
   return (fn, runOptions) => instance.run(fn, runOptions);
 }

--- a/src/experimental/call/create-retryable-call.ts
+++ b/src/experimental/call/create-retryable-call.ts
@@ -82,7 +82,7 @@ export type RetryCallRunOptions = {
 };
 
 /**
- * The attempt the driver committed to: the one whose call function returned,
+ * The attempt that ended the retry loop: the one whose call function returned,
  * after which no further fail-over is possible.
  *
  * Deliberately distinct from the model-level `SuccessAttempt`, which carries a
@@ -91,25 +91,23 @@ export type RetryCallRunOptions = {
  * the options are only the per-attempt overrides, since the driver has no call
  * options of its own.
  */
-export type RetryCallCommitAttempt<MODEL extends AnyModel = LanguageModel> = {
-  type: 'commit';
-  /** The model whose attempt committed. */
+export type RetryCallCompleteAttempt<MODEL extends AnyModel = LanguageModel> = {
+  /** The model whose attempt ended the loop. */
   model: MODEL;
-  /** The per-attempt overrides applied to the committed attempt. */
+  /** The per-attempt overrides applied to that attempt. */
   options: RetryCallOptions<MODEL>;
 };
 
 /**
- * The context passed to `onCommit`, with the committed attempt and the
- * attempts that were retried before it.
+ * The context passed to `onComplete`, with the attempt that ended the loop and
+ * the attempts that were retried before it.
  */
-export type RetryCallCommitContext<MODEL extends AnyModel = LanguageModel> = {
-  /** The attempt that committed. */
-  current: RetryCallCommitAttempt<MODEL>;
+export type RetryCallCompleteContext<MODEL extends AnyModel = LanguageModel> = {
+  /** The attempt that ended the loop. */
+  current: RetryCallCompleteAttempt<MODEL>;
   /**
    * The preceding attempts that were retried, in order. Empty when the first
-   * attempt committed. The committed attempt is `current` and is not repeated
-   * here.
+   * attempt returned. The final attempt is `current` and is not repeated here.
    */
   attempts: Array<RetryAttempt<MODEL>>;
 };
@@ -161,28 +159,26 @@ export interface RetryableCallOptions<MODEL extends AnyModel = LanguageModel> {
     context: RetryContext<MODEL>,
   ) => void | OnRetryOverrides<MODEL> | Promise<void | OnRetryOverrides<MODEL>>;
   /**
-   * Called once an attempt commits: the call function returned, so the driver
-   * has locked that attempt in and will not fail over again. Reports the model
-   * that handled it and the attempts that were retried before it.
+   * Called once the call function returns, so the driver stops retrying.
+   * Reports the model that handled it and the attempts retried before it.
    *
    * Not named `onSuccess`, because how much has to succeed before the call
    * function returns is the call function's choice, not the driver's. A
    * `generateText` call has fully completed by then; a `streamText` call has
    * only produced its result object, and whatever it goes on to stream — or
-   * fail with — is past the driver's reach. The stream wrapper moves the
-   * boundary to the first content part, which is as late as anything can still
-   * fail over.
+   * fail with — is past the driver's reach. For streaming, prefer
+   * `createRetryableStream`, whose `onCommit` waits for the first content part.
    *
    * The result is not reported here: the driver never inspects it, and the
    * caller receives it, correctly typed, from `run`.
    */
-  onCommit?: (context: RetryCallCommitContext<MODEL>) => void;
+  onComplete?: (context: RetryCallCompleteContext<MODEL>) => void;
   /**
-   * Called once when the attempts are exhausted without committing: no retry
+   * Called once when the attempts are exhausted without completing: no retry
    * matched, every candidate was tried, the caller's signal was already
    * aborted, or the caller aborted during a backoff delay. `context.error` is
    * the error the run rejects with, and `context.current` the attempt that
-   * failed last. The counterpart to `onCommit`.
+   * failed last. The counterpart to `onComplete`.
    *
    * Reports attempt failures, so it stays silent for a rejection that no
    * attempt caused — a callback of your own throwing, or a retryable throwing
@@ -245,7 +241,7 @@ function resolveRetryOptions<MODEL extends AnyModel>(
 class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
   /**
    * The options under their call-level types. `BaseRetryableModel` stores them
-   * under the model-level ones, which have no `onCommit` at all, so this is the
+   * under the model-level ones, which have no `onComplete` at all, so this is the
    * handle the loop reads the hooks through.
    */
   private readonly callOptions: ResolvedCallOptions<MODEL>;
@@ -256,18 +252,18 @@ class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
   }
 
   /**
-   * Fire the `onCommit` callback for a call that returned.
+   * Fire the `onComplete` callback for a call that returned.
    *
-   * No cast, unlike {@link RetryableCall.emitFailure}: the commit context is
+   * No cast, unlike {@link RetryableCall.emitFailure}: the complete context is
    * declared over `MODEL` directly, whereas the shared contexts are declared
    * over `ResolvedModel<MODEL>` — the same type at runtime, but not provably so
    * for a generic `MODEL`.
    */
-  private emitCommit(
-    current: RetryCallCommitAttempt<MODEL>,
+  private emitComplete(
+    current: RetryCallCompleteAttempt<MODEL>,
     attempts: Array<RetryAttempt<MODEL>>,
   ) {
-    this.callOptions.onCommit?.({ current, attempts });
+    this.callOptions.onComplete?.({ current, attempts });
   }
 
   /**
@@ -375,7 +371,7 @@ class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
 
         /**
          * Only the call itself is guarded. Everything that runs once the
-         * attempt has committed stays outside, so a throwing `onCommit`
+         * attempt has completed stays outside, so a throwing `onComplete`
          * handler cannot be mistaken for a failed attempt and re-run a call
          * that already succeeded.
          */
@@ -461,16 +457,13 @@ class RetryableCall<MODEL extends AnyModel> extends BaseRetryableModel<MODEL> {
         recorder?.endAttempt({ attempt: attemptNumber, outcome: 'success' });
         this.updateStickyModel(startModel);
 
-        this.emitCommit(
-          { type: 'commit', model: attemptModel, options },
-          attempts,
-        );
+        this.emitComplete({ model: attemptModel, options }, attempts);
 
         return result;
       }
     } catch (error) {
       /**
-       * Every way the loop can end without committing lands here: no retry
+       * Every way the loop can end without completing lands here: no retry
        * matched, the caller's signal was already aborted, the caller aborted
        * during a backoff delay, or a caller-supplied handler threw. Reporting
        * once at the boundary is what makes it impossible to reject without

--- a/src/experimental/call/index.ts
+++ b/src/experimental/call/index.ts
@@ -2,8 +2,8 @@ export {
   createRetryableCall,
   type RetryCall,
   type RetryCallAttempt,
-  type RetryCallCommitAttempt,
-  type RetryCallCommitContext,
+  type RetryCallCompleteAttempt,
+  type RetryCallCompleteContext,
   type RetryCallRunOptions,
   type RetryableCallOptions,
 } from './create-retryable-call.js';

--- a/src/experimental/call/index.ts
+++ b/src/experimental/call/index.ts
@@ -2,6 +2,8 @@ export {
   createRetryableCall,
   type RetryCall,
   type RetryCallAttempt,
+  type RetryCallCommitAttempt,
+  type RetryCallCommitContext,
   type RetryCallRunOptions,
   type RetryableCallOptions,
 } from './create-retryable-call.js';

--- a/src/experimental/stream/create-retryable-stream.test-d.ts
+++ b/src/experimental/stream/create-retryable-stream.test-d.ts
@@ -1,0 +1,36 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { MockLanguageModel } from '../../internal/test-utils.js';
+import type {
+  LanguageModel,
+  RetryAttempt,
+  RetryCallOptions,
+} from '../../types.js';
+import { createRetryableStream } from './create-retryable-stream.js';
+
+describe('createRetryableStream types', () => {
+  it('should type the commit context with what the wrapper knows', () => {
+    // Act
+    createRetryableStream({
+      model: MockLanguageModel.from(),
+      retries: [],
+      onCommit: (context) => {
+        // Assert
+        expectTypeOf(context.current.model).toEqualTypeOf<LanguageModel>();
+        expectTypeOf(context.current.options).toEqualTypeOf<
+          RetryCallOptions<LanguageModel>
+        >();
+        expectTypeOf(context.attempts).toEqualTypeOf<
+          Array<RetryAttempt<LanguageModel>>
+        >();
+        expectTypeOf(context.current).not.toHaveProperty('result');
+      },
+    });
+  });
+
+  it('should not accept the call driver onComplete', () => {
+    // Assert — the positive hook is named for this layer's boundary.
+    expectTypeOf(createRetryableStream)
+      .parameter(0)
+      .not.toHaveProperty('onComplete');
+  });
+});

--- a/src/experimental/stream/create-retryable-stream.test.ts
+++ b/src/experimental/stream/create-retryable-stream.test.ts
@@ -472,16 +472,16 @@ describe('createRetryableStream', () => {
       });
 
       // Act
-      await retryableStream((attempt) =>
+      const committed = await retryableStream((attempt) =>
         attempt.model === primary
           ? streamOf([Language.streamError(new Error('boom'))])
           : fallbackResult,
       );
 
-      // Assert
+      // Assert — the result reaches the caller, not the hook.
+      expect(committed).toBe(fallbackResult);
       expect(onCommit).toHaveBeenCalledTimes(1);
       expect(onCommit.mock.calls[0]![0].current.model).toBe(fallback);
-      expect(onCommit.mock.calls[0]![0].current.result).toBe(fallbackResult);
       expect(onCommit.mock.calls[0]![0].attempts.length).toBe(1);
     });
 

--- a/src/experimental/stream/create-retryable-stream.test.ts
+++ b/src/experimental/stream/create-retryable-stream.test.ts
@@ -458,6 +458,111 @@ describe('createRetryableStream', () => {
     });
   });
 
+  describe('outcome hooks', () => {
+    it('should call onCommit with the model that committed', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const fallback = MockLanguageModel.from();
+      const fallbackResult = streamOf([{ type: 'text-delta', text: 'OK' }]);
+      const onCommit = vi.fn();
+      const retryableStream = createRetryableStream({
+        model: primary,
+        retries: [fallback],
+        onCommit,
+      });
+
+      // Act
+      await retryableStream((attempt) =>
+        attempt.model === primary
+          ? streamOf([Language.streamError(new Error('boom'))])
+          : fallbackResult,
+      );
+
+      // Assert
+      expect(onCommit).toHaveBeenCalledTimes(1);
+      expect(onCommit.mock.calls[0]![0].current.model).toBe(fallback);
+      expect(onCommit.mock.calls[0]![0].current.result).toBe(fallbackResult);
+      expect(onCommit.mock.calls[0]![0].attempts.length).toBe(1);
+    });
+
+    it('should call onCommit at the commit point, not at stream completion', async () => {
+      // Arrange — content, then an error the caller inherits past the commit.
+      const primary = MockLanguageModel.from();
+      const fallback = MockLanguageModel.from();
+      const onCommit = vi.fn();
+      const onFailure = vi.fn();
+      const retryableStream = createRetryableStream({
+        model: primary,
+        retries: [fallback],
+        onCommit,
+        onFailure,
+      });
+
+      // Act
+      await retryableStream(() =>
+        streamOf([
+          { type: 'text-delta', text: 'OK' },
+          Language.streamError(new Error('mid-stream')),
+        ]),
+      );
+
+      // Assert — the post-commit error is the caller's, so it fires nothing.
+      expect(onCommit).toHaveBeenCalledTimes(1);
+      expect(onCommit.mock.calls[0]![0].current.model).toBe(primary);
+      expect(onFailure).toHaveBeenCalledTimes(0);
+    });
+
+    it('should call onFailure when every attempt fails before content', async () => {
+      // Arrange
+      const primary = MockLanguageModel.from();
+      const fallback = MockLanguageModel.from();
+      const onCommit = vi.fn();
+      const onFailure = vi.fn();
+      const retryableStream = createRetryableStream({
+        model: primary,
+        retries: [fallback],
+        onCommit,
+        onFailure,
+      });
+
+      // Act
+      await retryableStream(() =>
+        streamOf([Language.streamError(new Error('boom'))]),
+      ).catch(() => {});
+
+      // Assert
+      expect(onCommit).toHaveBeenCalledTimes(0);
+      expect(onFailure).toHaveBeenCalledTimes(1);
+      expect(RetryError.isInstance(onFailure.mock.calls[0]![0].error)).toBe(
+        true,
+      );
+      expect(onFailure.mock.calls[0]![0].current.model).toBe(fallback);
+      expect(onFailure.mock.calls[0]![0].attempts.length).toBe(2);
+    });
+
+    it('should call neither hook when retries are disabled', async () => {
+      // Arrange
+      const onCommit = vi.fn();
+      const onFailure = vi.fn();
+      const retryableStream = createRetryableStream({
+        model: MockLanguageModel.from(),
+        retries: [],
+        disabled: true,
+        onCommit,
+        onFailure,
+      });
+
+      // Act
+      await retryableStream(() =>
+        streamOf([{ type: 'text-delta', text: 'OK' }]),
+      );
+
+      // Assert
+      expect(onCommit).toHaveBeenCalledTimes(0);
+      expect(onFailure).toHaveBeenCalledTimes(0);
+    });
+  });
+
   describe('disabled', () => {
     it('should bypass retries when disabled', async () => {
       // Arrange
@@ -660,6 +765,45 @@ describe('streamText integration', () => {
       // Assert
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onCommit with the model that recovered the stream', async () => {
+      // Arrange
+      const primary = errorAtStartStreamModel(new Error('boom'));
+      const fallback = okStreamModel();
+      const onCommit = vi.fn();
+      const onFailure = vi.fn();
+
+      // Act
+      const result = await retryableStreamText(
+        { model: primary, retries: [fallback], onCommit, onFailure },
+        { prompt },
+      );
+      await result.text;
+
+      // Assert
+      expect(onCommit).toHaveBeenCalledTimes(1);
+      expect(onCommit.mock.calls[0]![0].current.model).toBe(fallback);
+      expect(onCommit.mock.calls[0]![0].attempts.length).toBe(1);
+      expect(onFailure).toHaveBeenCalledTimes(0);
+    });
+
+    it('should call onFailure when no retryable matches a pre-content error', async () => {
+      // Arrange
+      const primary = errorAtStartStreamModel(new Error('boom'));
+      const onCommit = vi.fn();
+      const onFailure = vi.fn();
+
+      // Act
+      await retryableStreamText(
+        { model: primary, retries: [], onCommit, onFailure },
+        { prompt },
+      ).catch(() => {});
+
+      // Assert
+      expect(onCommit).toHaveBeenCalledTimes(0);
+      expect(onFailure).toHaveBeenCalledTimes(1);
+      expect(onFailure.mock.calls[0]![0].current.model).toBe(primary);
     });
   });
 

--- a/src/experimental/stream/create-retryable-stream.ts
+++ b/src/experimental/stream/create-retryable-stream.ts
@@ -2,6 +2,7 @@ import {
   createRetryableCall,
   type RetryableCallOptions,
   type RetryCallAttempt,
+  type RetryCallCompleteContext,
   type RetryCallRunOptions,
 } from '../call/create-retryable-call.js';
 import { detectStreamCommit } from './detect-stream-commit.js';
@@ -24,8 +25,26 @@ const resolveStream = (result: StreamResult): ReadableStream<unknown> =>
 
 /**
  * Options for {@link createRetryableStream}.
+ *
+ * The call driver's `onComplete` is replaced by `onCommit`, which is the same
+ * callback observed at a later boundary: this wrapper's attempt does not return
+ * until the stream has committed, so "the call function returned" and "the
+ * first content part arrived" are the same moment here.
  */
-export type RetryableStreamOptions = RetryableCallOptions;
+export type RetryableStreamOptions = Omit<
+  RetryableCallOptions,
+  'onComplete'
+> & {
+  /**
+   * Called once an attempt commits — its first content part reached the
+   * stream — so the wrapper will not fail over again. Not when the stream
+   * finishes: past this point the stream is the caller's, and an error during
+   * consumption fires nothing. For a hook that waits for the stream to
+   * actually finish, use the model wrapper's `onSuccess` below this one, or
+   * the SDK's own `onFinish`.
+   */
+  onCommit?: (context: RetryCallCompleteContext) => void;
+};
 
 /**
  * Runs a stream-producing function with retry/fail-over, deciding the outcome
@@ -70,14 +89,17 @@ export type RetryableStream = <RESULT extends StreamResult>(
  * The outcome hooks follow that same boundary: `onCommit` fires once an attempt
  * commits — the first content part, not the end of the stream — and `onFailure`
  * fires when every attempt failed before committing. Past the commit point the
- * caller owns the stream, so an error during consumption fires neither. For a
- * hook that waits for the stream to actually finish, use the model wrapper's
- * `onSuccess` (or the SDK's own `onFinish`) below this one.
+ * caller owns the stream, so an error during consumption fires neither.
  */
 export function createRetryableStream(
   options: RetryableStreamOptions,
 ): RetryableStream {
-  const run = createRetryableCall(options);
+  const { onCommit, ...callOptions } = options;
+  /**
+   * The attempt only returns once the stream has committed, so the driver's
+   * completion callback is exactly this wrapper's commit callback.
+   */
+  const run = createRetryableCall({ ...callOptions, onComplete: onCommit });
 
   return <RESULT extends StreamResult>(
     streamFn: (attempt: RetryCallAttempt) => RESULT | Promise<RESULT>,

--- a/src/experimental/stream/create-retryable-stream.ts
+++ b/src/experimental/stream/create-retryable-stream.ts
@@ -2,9 +2,13 @@ import {
   createRetryableCall,
   type RetryableCallOptions,
   type RetryCallAttempt,
-  type RetryCallCompleteContext,
   type RetryCallRunOptions,
 } from '../call/create-retryable-call.js';
+import type {
+  LanguageModel,
+  RetryAttempt,
+  RetryCallOptions,
+} from '../../types.js';
 import { detectStreamCommit } from './detect-stream-commit.js';
 
 /**
@@ -22,6 +26,35 @@ export type StreamResult =
 /** Resolve the re-readable part stream, preferring the v7 `stream` getter. */
 const resolveStream = (result: StreamResult): ReadableStream<unknown> =>
   'stream' in result ? result.stream : result.fullStream;
+
+/**
+ * The attempt that committed: the one whose first content part reached the
+ * stream, after which no further fail-over is possible.
+ *
+ * Language-model-shaped rather than generic, since commit is detected from the
+ * AI SDK stream protocol and has no meaning for the other model kinds.
+ */
+export type RetryStreamCommitAttempt = {
+  /** The model whose attempt committed. */
+  model: LanguageModel;
+  /** The per-attempt overrides applied to the committed attempt. */
+  options: RetryCallOptions<LanguageModel>;
+};
+
+/**
+ * The context passed to `onCommit`, with the committed attempt and the
+ * attempts that were retried before it.
+ */
+export type RetryStreamCommitContext = {
+  /** The attempt that committed. */
+  current: RetryStreamCommitAttempt;
+  /**
+   * The preceding attempts that were retried, in order. Empty when the first
+   * attempt committed. The committed attempt is `current` and is not repeated
+   * here.
+   */
+  attempts: Array<RetryAttempt<LanguageModel>>;
+};
 
 /**
  * Options for {@link createRetryableStream}.
@@ -43,7 +76,7 @@ export type RetryableStreamOptions = Omit<
    * actually finish, use the model wrapper's `onSuccess` below this one, or
    * the SDK's own `onFinish`.
    */
-  onCommit?: (context: RetryCallCompleteContext) => void;
+  onCommit?: (context: RetryStreamCommitContext) => void;
 };
 
 /**

--- a/src/experimental/stream/create-retryable-stream.ts
+++ b/src/experimental/stream/create-retryable-stream.ts
@@ -66,6 +66,13 @@ export type RetryableStream = <RESULT extends StreamResult>(
  * Returns the winning attempt's result unchanged, so the caller drives the body
  * (`stream`, `toUIMessageStreamResponse()`, …) with back-pressure preserved
  * past the commit point.
+ *
+ * The outcome hooks follow that same boundary: `onCommit` fires once an attempt
+ * commits — the first content part, not the end of the stream — and `onFailure`
+ * fires when every attempt failed before committing. Past the commit point the
+ * caller owns the stream, so an error during consumption fires neither. For a
+ * hook that waits for the stream to actually finish, use the model wrapper's
+ * `onSuccess` (or the SDK's own `onFinish`) below this one.
  */
 export function createRetryableStream(
   options: RetryableStreamOptions,

--- a/src/experimental/stream/index.ts
+++ b/src/experimental/stream/index.ts
@@ -1,11 +1,9 @@
-export type {
-  RetryCallCompleteAttempt,
-  RetryCallCompleteContext,
-} from '../call/create-retryable-call.js';
 export {
   createRetryableStream,
   type RetryableStream,
   type RetryableStreamOptions,
+  type RetryStreamCommitAttempt,
+  type RetryStreamCommitContext,
   type StreamResult,
 } from './create-retryable-stream.js';
 export { detectStreamCommit } from './detect-stream-commit.js';

--- a/src/experimental/stream/index.ts
+++ b/src/experimental/stream/index.ts
@@ -1,3 +1,7 @@
+export type {
+  RetryCallCommitAttempt,
+  RetryCallCommitContext,
+} from '../call/create-retryable-call.js';
 export {
   createRetryableStream,
   type RetryableStream,

--- a/src/experimental/stream/index.ts
+++ b/src/experimental/stream/index.ts
@@ -1,6 +1,6 @@
 export type {
-  RetryCallCommitAttempt,
-  RetryCallCommitContext,
+  RetryCallCompleteAttempt,
+  RetryCallCompleteContext,
 } from '../call/create-retryable-call.js';
 export {
   createRetryableStream,

--- a/src/internal/retryable-language-model.test.ts
+++ b/src/internal/retryable-language-model.test.ts
@@ -1135,6 +1135,46 @@ describe('generateText', () => {
       expect(onFailureSpy).not.toHaveBeenCalled();
     });
 
+    it('should NOT call onFailure when an onSuccess handler throws', async () => {
+      // Arrange — a throwing hook is not an attempt failure. The request
+      // succeeded, so reporting it as a failure would fire both callbacks
+      // for one request, with a stale attempt as `current`.
+      /**
+       * Explicit model ids so the shared auto-increment counter is untouched
+       * and the inline snapshots further down the file stay stable.
+       */
+      const baseModel = MockLanguageModel.from(
+        { doGenerate: retryableError },
+        { modelId: 'throwing-on-success-base' },
+      );
+      const fallbackModel = MockLanguageModel.from(
+        { doGenerate: mockResult },
+        { modelId: 'throwing-on-success-fallback' },
+      );
+      const handlerError = new Error('onSuccess blew up');
+      const onFailureSpy = vi.fn<OnFailure>();
+      const onSuccessSpy = vi.fn<OnSuccess>(() => {
+        throw handlerError;
+      });
+
+      // Act
+      const result = generateText({
+        model: createRetryableModel({
+          model: baseModel,
+          retries: [fallbackModel],
+          onFailure: onFailureSpy,
+          onSuccess: onSuccessSpy,
+        }),
+        prompt,
+      });
+      await expect(result).rejects.toThrow();
+
+      // Assert — the handler error surfaces unwrapped.
+      await result.catch((e) => expect(e).toBe(handlerError));
+      expect(onSuccessSpy).toHaveBeenCalledTimes(1);
+      expect(onFailureSpy).not.toHaveBeenCalled();
+    });
+
     it('should NOT call onSuccess on failure', async () => {
       // Arrange
       const baseModel = MockLanguageModel.from({ doGenerate: retryableError });
@@ -4005,6 +4045,43 @@ describe('streamText', () => {
       expect(failureCall.current.model).toBe(baseModel);
       expect(failureCall.attempts.length).toBe(1);
       expect(failureCall.error).toBe(nonRetryableError);
+    });
+
+    it('should call onFailure when the re-stream after a retry fails', async () => {
+      // Arrange — the base stream errors before content, so a retry is
+      // selected, but creating the fallback's stream throws and nothing
+      // matches it. That failure happens on the re-stream path, past the
+      // terminal branches of the read loop.
+      /**
+       * Explicit model ids so the shared auto-increment counter is untouched
+       * and the inline snapshots further down the file stay stable.
+       */
+      const baseModel = MockLanguageModel.from(
+        { doStream: errorStreamChunks(retryableError) },
+        { modelId: 're-stream-failure-base' },
+      );
+      const fallbackModel = MockLanguageModel.from(
+        { doStream: nonRetryableError },
+        { modelId: 're-stream-failure-fallback' },
+      );
+      const onFailureSpy = vi.fn<OnFailure>();
+
+      // Act
+      const result = streamText({
+        model: createRetryableModel({
+          model: baseModel,
+          retries: [fallbackModel],
+          onFailure: onFailureSpy,
+        }),
+        prompt,
+      });
+      const parts = await Iterables.toArray(result.fullStream);
+
+      // Assert — surfaced as an error part, not a stream rejection, so the
+      // consumer's own onError still fires.
+      expect(RetryError.isInstance(errorFromChunks(parts))).toBe(true);
+      expect(onFailureSpy).toHaveBeenCalledTimes(1);
+      expect(onFailureSpy.mock.calls[0]![0].attempts.length).toBe(2);
     });
 
     it('should NOT call onFailure on a successful stream', async () => {

--- a/src/internal/retryable-language-model.ts
+++ b/src/internal/retryable-language-model.ts
@@ -352,8 +352,16 @@ export class RetryableLanguageModel
      */
     const attempts: Array<RetryAttempt<LanguageModel>> = [];
     let operationError: unknown;
+    /**
+     * Only the retry loop is guarded. `onSuccess` runs after it, so a throwing
+     * handler is not reported as an attempt failure — the request succeeded,
+     * and firing `onFailure` too would report both outcomes for one request
+     * with a stale attempt as `current`.
+     */
+    let result: LanguageModelResult;
+    let finalCallOptions: LanguageModelCallOptions;
     try {
-      const { result, callOptions: finalCallOptions } = await this.withRetry({
+      const retried = await this.withRetry({
         fn: async (retryCallOptions) => {
           return this.currentModel.doGenerate(retryCallOptions);
         },
@@ -361,20 +369,8 @@ export class RetryableLanguageModel
         attempts,
         recorder,
       });
-
-      this.updateStickyModel(startModel);
-
-      this.options.onSuccess?.({
-        current: {
-          type: 'success',
-          model: this.currentModel,
-          result,
-          options: finalCallOptions,
-        },
-        attempts,
-      });
-
-      return result;
+      result = retried.result;
+      finalCallOptions = retried.callOptions;
     } catch (error) {
       operationError = error;
       this.emitFailure(attempts, error);
@@ -386,6 +382,20 @@ export class RetryableLanguageModel
         error: operationError,
       });
     }
+
+    this.updateStickyModel(startModel);
+
+    this.options.onSuccess?.({
+      current: {
+        type: 'success',
+        model: this.currentModel,
+        result,
+        options: finalCallOptions,
+      },
+      attempts,
+    });
+
+    return result;
   }
 
   async doStream(
@@ -858,6 +868,19 @@ export class RetryableLanguageModel
             },
             attempts,
           });
+        } catch (error) {
+          /**
+           * Anything that escaped the loop without reaching one of its
+           * terminal branches — most notably a re-stream whose own retries
+           * are exhausted. Letting it escape `start()` would reject the
+           * stream, which bypasses the consumer's `onError` entirely, so it
+           * is surfaced as an error part like every other unrecovered
+           * failure.
+           */
+          operationError = error;
+          this.emitFailure(attempts, error);
+          controller.enqueue({ type: 'error', error });
+          controller.close();
         } finally {
           recorder?.endOperation({
             provider: this.currentModel.provider,


### PR DESCRIPTION
## Summary

- `createRetryableCall` and `createRetryableStream` gain a positive-outcome callback plus `onFailure`. They previously exposed only `onError`/`onRetry`, so there was no single place to observe which model handled a run and after how many failed attempts.
- The positive hook is named per layer, for the boundary each one can actually observe: **`onComplete`** on the call driver (the call function returned) and **`onCommit`** on the stream wrapper (the first content part arrived). Neither is `onSuccess`, which keeps meaning "fully finished" on the model wrappers. Each layer owns its context type (`RetryCallCompleteContext`, `RetryStreamCommitContext`), reporting only what it knows — notably no `result`, since the caller already receives that from `run`.
- The outcome is now reported once at the loop boundary instead of at each terminal `throw`, so aborting during a backoff delay or a throwing `onRetry` handler can no longer reject without reporting. That also closes a gap where the telemetry operation span recorded no error on those paths.
- The success path moved out of the attempt's `try` block, so a throwing hook is no longer mistaken for a failed attempt. Previously a throwing `onCommit` re-ran an already-committed call against the fallback — a duplicate billed request for a `streamText`.
- A separate commit (`e732dc8`) fixes two pre-existing bugs found while checking whether these changes should port to the model wrapper: `doStream` could let an error escape `start()` and reject the stream — bypassing the consumer's `onError`, `onFailure`, and the operation span alike — and `doGenerate` fired both `onSuccess` and `onFailure` when a handler threw.

`src/types.ts` is untouched; the model wrappers' public API is unchanged.

## Test plan

- [ ] `pnpm test` — 706 passing
- [ ] `npx tsc --noEmit` — clean for `src/` (the `examples/` errors are pre-existing and need a built `dist/`)
- [ ] `pnpm lint` — 0 errors
- [ ] Call driver: `onComplete` fires once on success and reports the recovering model; `onFailure` covers no-retry-matched, exhausted retries, abort-before-retry, and abort-during-backoff
- [ ] Stream wrapper: `onCommit` fires at the commit point rather than at stream completion, and a post-commit error fires neither hook
- [ ] Model wrapper: a re-stream whose retries are exhausted surfaces an error part (not a stream rejection) and calls `onFailure`; a throwing `onSuccess` does not also trigger `onFailure`